### PR TITLE
Update basic-http-examples.mdx

### DIFF
--- a/templates/protocols/dns.mdx
+++ b/templates/protocols/dns.mdx
@@ -92,7 +92,7 @@ id: dummy-cname-a
 info:
   name: Dummy A dns request
   author: mzack9999
-  severity: none
+  severity: info
   description: Checks if CNAME and A record is returned.
 
 dns:

--- a/templates/protocols/http/basic-http-examples.mdx
+++ b/templates/protocols/http/basic-http-examples.mdx
@@ -205,7 +205,7 @@ id: time-based-matcher
 info:
   name: DSL based response time matcher
   author: pdteam
-  severity: none
+  severity: info
 
 http:
   - raw:


### PR DESCRIPTION
`none` is an invalid severity and will result in the `Could not load template dns.yaml: Invalid severity: none` error.