### PR TITLE
add reusable dynamic matchers + internal matchers etc docs

### DIFF
--- a/templates/protocols/code.mdx
+++ b/templates/protocols/code.mdx
@@ -157,6 +157,14 @@ code:
 # digest: 4a0a00473045022100eb01da6b97893e7868c584f330a0cd52df9bddac005860bb8595ba5b8aed58c9022050043feac68d69045cf320cba9298a2eb2e792ea4720d045d01e803de1943e7d:4a3eb6b4988d95847d4203be25ed1d46
 ```
 
+## Running Code Templates
+
+By default Nuclei will not execute code templates. To enable code protocol execution, `-code` flag needs to be explicitly passed to nuclei.
+
+```bash
+nuclei -t code-template.yaml -code
+```
+
 ## Learn More 
 
 <Info>

--- a/templates/protocols/flow.mdx
+++ b/templates/protocols/flow.mdx
@@ -253,11 +253,11 @@ http:
 
     matchers:
       - type: dsl
-        internal: true  # <- updated logic (this will skip printing this event/result)
         dsl:
           - 'status_code == 200'
           - 'contains(body, "Backup Migration")'
         condition: and
+        internal: true  # <- updated logic (this will skip printing this event/result)
 
   - method: POST
     path:

--- a/templates/protocols/flow.mdx
+++ b/templates/protocols/flow.mdx
@@ -226,3 +226,50 @@ log(uniq.Values())
 And that's it, this automatically converts any slice/array to map and removes duplicates from it and returns a slice/array of unique values
 
 > Similar to DSL helper functions . we can either use built in functions available with `Javscript (ECMAScript 5.1)` or use DSL helper functions and its upto user to decide which one to uses.
+
+
+### Skip Internal Matchers in MultiProtocol / Flow Templates
+
+Before nuclei v3.1.4 , A template like [`CVE-2023-43177`](https://github.com/projectdiscovery/nuclei-templates/blob/c5be73e328ebd9a0c122ea0324f60bbdd7eb940d/http/cves/2023/CVE-2023-43177.yaml#L28) which has multiple requests/protocols and uses `flow` for logic, used to only return one result but it conflicted with logic when `for` loop was used in `flow` to fix this nuclei engine from v3.1.4 will print all events/results in a template and template writers can use `internal: true` in matchers to skip printing of events/results just like dynamic extractors.
+
+Note: this is only relevant if matchers/extractors are used in previous requests/protocols
+
+Example of [`CVE-2023-6553`](https://github.com/projectdiscovery/nuclei-templates/blob/c5be73e328ebd9a0c122ea0324f60bbdd7eb940d/http/cves/2023/CVE-2023-6553.yaml#L21) with new `internal: true` logic would be
+
+```yaml
+id: CVE-2023-6553
+
+info:
+  name: Worpress Backup Migration <= 1.3.7 - Unauthenticated Remote Code Execution
+  author: FLX
+  severity: critical
+
+flow: http(1) && http(2)
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/backup-backup/readme.txt"
+
+    matchers:
+      - type: dsl
+        internal: true  # <- updated logic (this will skip printing this event/result)
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "Backup Migration")'
+        condition: and
+
+  - method: POST
+    path:
+      - "{{BaseURL}}/wp-content/plugins/backup-backup/includes/backup-heart.php"
+    headers:
+      Content-Dir: "{{rand_text_alpha(10)}}"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'len(body) == 0'
+          - 'status_code == 200'
+          - '!contains(body, "Incorrect parameters")'
+        condition: and
+```

--- a/templates/protocols/network.mdx
+++ b/templates/protocols/network.mdx
@@ -130,6 +130,13 @@ exclude-ports: 80,443
 ```
 When `exclude-ports` is used, the default reserved ports list will be overwritten. This means that if you want to run a network template on port `80`, you will have to explicitly specify it in the port field.
 
+Starting from Nuclei v3.1.0 `port` field supports comma seperated values and multi ports can be specified in the port field. For example, if you want to run a network template on port `5432` and `5433`, you can specify it in the port field like this:
+
+```yaml
+port: 5432,5433
+```
+In this case, Nuclei will first check if port is open from list and run template only on open ports
+
 #### Matchers / Extractor Parts
 
 Valid `part` values supported by **Network** protocol for Matchers / Extractor are - 

--- a/templates/reference/extractors.mdx
+++ b/templates/reference/extractors.mdx
@@ -121,3 +121,36 @@ extractors:
 The above extractor with name `csrf_token` will hold the value extracted by `([[:alnum:]]{16})` as `abcdefgh12345678`. 
 
 If no group option is provided with this regex, the above extractor with name `csrf_token` will hold the full match (by `<input name="csrf_token"\stype="hidden"\svalue="([[:alnum:]]{16})" />`) as `<input name="csrf_token" type="hidden" value="abcdefgh12345678" />`.
+
+### Reusable Dynamic Extractors
+
+With Nuclei v3.1.4 you can now reuse dynamic extracted value (ex: csrf_token in above example) immediately in next extractors and is by default available in subsequent requests
+
+Example:
+```
+id: basic-raw-example
+
+info:
+  name: Test RAW Template
+  author: pdteam
+  severity: info
+
+
+http:
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+
+    extractors:
+      - type: regex
+        name: title
+        group: 1
+        regex:
+          - '<title>(.*)<\/title>'
+        internal: true
+
+      - type: dsl
+        dsl:
+          - '"Title is " + title'
+```

--- a/templates/reference/matchers.mdx
+++ b/templates/reference/matchers.mdx
@@ -211,11 +211,11 @@ http:
 
     matchers:
       - type: dsl
-        internal: true  # <- updated logic (this will skip printing this event/result)
         dsl:
           - 'status_code == 200'
           - 'contains(body, "Backup Migration")'
         condition: and
+        internal: true  # <- updated logic (this will skip printing this event/result)
 
   - method: POST
     path:

--- a/templates/reference/matchers.mdx
+++ b/templates/reference/matchers.mdx
@@ -185,3 +185,49 @@ While using multiple matchers the default condition is to follow OR operation in
           - "PHP"
         part: body
 ```
+
+### Internal Matchers
+
+When writing multi-protocol or `flow` based templates, there might be a case where we need to validate/match first request then proceed to next request and a good example of this is [`CVE-2023-6553`](https://github.com/projectdiscovery/nuclei-templates/blob/c5be73e328ebd9a0c122ea0324f60bbdd7eb940d/http/cves/2023/CVE-2023-6553.yaml#L21)
+
+In this template, we are first checking if target is actual using `Backup Migration` plugin using matchers and if true then proceed to next request with help of `flow`
+
+But this will print two results, one for each request match since we are using the first request matchers as a pre-condition to proceed to next request we can mark it as internal using `internal: true` in the matchers block.
+
+```yaml
+id: CVE-2023-6553
+
+info:
+  name: Worpress Backup Migration <= 1.3.7 - Unauthenticated Remote Code Execution
+  author: FLX
+  severity: critical
+
+flow: http(1) && http(2)
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/backup-backup/readme.txt"
+
+    matchers:
+      - type: dsl
+        internal: true  # <- updated logic (this will skip printing this event/result)
+        dsl:
+          - 'status_code == 200'
+          - 'contains(body, "Backup Migration")'
+        condition: and
+
+  - method: POST
+    path:
+      - "{{BaseURL}}/wp-content/plugins/backup-backup/includes/backup-heart.php"
+    headers:
+      Content-Dir: "{{rand_text_alpha(10)}}"
+
+    matchers:
+      - type: dsl
+        dsl:
+          - 'len(body) == 0'
+          - 'status_code == 200'
+          - '!contains(body, "Incorrect parameters")'
+        condition: and
+```


### PR DESCRIPTION
### Proposed Changes

Add missing docs for following features/changes

- `internal: true` in matcher
-  Reusable Dynamic Extractor
- `-code` flag to run code templates
-  multi port support in `ports` field of network protocol