### PR TITLE
Fix the broken link for the uncover integration

### DIFF
--- a/templates/structure.mdx
+++ b/templates/structure.mdx
@@ -58,7 +58,7 @@ The best part of this is you can simply share your crafted template with your te
 
 ## Metadata
 
-It's possible to add metadata nodes, for example, to integrates with [uncover](https://github.com/projectdiscovery/uncover) (cf. [Uncover Integration](https://nuclei.projectdiscovery.io/nuclei/get-started/#uncover-integration)).
+It's possible to add metadata nodes, for example, to integrates with [uncover](https://github.com/projectdiscovery/uncover) (cf. [Uncover Integration](https://docs.projectdiscovery.io/tools/nuclei/running#scan-on-internet-database)).
 
 The metadata nodes are crafted this way: `<engine>-query: '<query>'` where:
 


### PR DESCRIPTION
Thank you for providing useful docs :bow:

Since I found one broken link(`cf. Uncover Integration`) in the Metadata section([ref](https://docs.projectdiscovery.io/templates/structure#metadata))) in the documentation reference, this PR replace it with the link([ref](https://docs.projectdiscovery.io/tools/nuclei/running#scan-on-internet-database)) which has the similar content.

According to the past Wayback Machine history([ref](https://web.archive.org/web/20230527223921/https://nuclei.projectdiscovery.io/nuclei/get-started/#uncover-integration)), it looks the heading has changed from `Uncover Integration` to `Scan on internet database`. However, the content is totally same. Thus, I think the link can be replaced, and it would be useful for readers rather than redirecting the top page of nuclei docs([ref](https://docs.projectdiscovery.io/introduction#uncover-integration)).

## Difference of the destination page
### Before in the legacy docs
![Screenshot 2024-04-29 at 15 47 17](https://github.com/projectdiscovery/docs/assets/29667656/bd856802-168c-4d9c-bbba-e48deda3bbf3)

### After in the new docs
![Screenshot 2024-04-29 at 15 47 39](https://github.com/projectdiscovery/docs/assets/29667656/16b466ba-5a0b-4346-a333-c4fc0fc9158a)

