### PR TITLE
docs: punctuation and typo fix

### DIFF
--- a/documentation-nav.mdx
+++ b/documentation-nav.mdx
@@ -15,8 +15,8 @@ We're continuously working to provide a centralized and comprehensive set of res
 
 Here are a few tips on how to get around: 
 - Use search to locate a specific term or topic. For more specific results, use a phrase or question for a detailed AI-powered response. 
-- Navigate through sections with the tabs at the top (Tools, Templates, Cloud Platform, etc.) 
-- Check out the [Help](/help) tab for support and info on joining our community
+- Navigate through sections with the tabs at the top (Tools, Templates, Cloud Platform, etc.)
+- Check out the [Help](/help) tab for support and info on joining our community.
 
 ## Content Overview 
 

--- a/overview.mdx
+++ b/overview.mdx
@@ -31,7 +31,7 @@ and vulnerabilities.
 
 ## ProjectDiscovery Cloud Platform
 
-[ProjectDiscovery Cloud Platform](https://projectdiscovery.io/platform) (PDCP) s a cloud-hosted security platform designed to provide continuous visibility across your external attack surface by detecting exploitable vulnerabilities and misconfigurations. 
+[ProjectDiscovery Cloud Platform](https://projectdiscovery.io/platform) (PDCP) is a cloud-hosted security platform designed to provide continuous visibility across your external attack surface by detecting exploitable vulnerabilities and misconfigurations. 
 It is built to solve a variety of use cases, and scale to support the key workflows application security teams need to secure their infrastructure.
 
 Visit [the ProjectDiscovery Cloud Platform](/cloud/introduction) section of our documentation to learn more. 


### PR DESCRIPTION
Hello!

I added a period to the "Navigating the Docs" section in `documentation-nav.mdx` to maintain style consistency with the rest of the doc.

I also fixed a typo in `overview.mdx`. The corrected text now reads "[ProjectDiscovery Cloud Platform](https://projectdiscovery.io/platform) (PDCP) **is** a cloud-hosted security platform".
