### PR TITLE
Remove dated fuzz info

### DIFF
--- a/tools/nuclei/running.mdx
+++ b/tools/nuclei/running.mdx
@@ -59,7 +59,6 @@ However, there are some exceptions regarding the templates that run by default:
 - [Code Templates](/templates/protocols/code) require the `-code` flag to execute.
 - [Headless Templates](/templates/protocols/headless) will not run unless you pass the `-headless` flag.
 - [Fuzzing Templates](/template/protocols/http/fuzzing-overview) will not run unless you pass the `-fuzz` flag.
-- A separate collection of [Fuzzing Templates](/templates/protocols/http/fuzzing-overview), located in a [different repository](https://github.com/projectdiscovery/fuzzing-templates), must be downloaded and configured separately for use.
 
 You can also run templates against a list of URLs:
 


### PR DESCRIPTION
There was a line referring to the old fuzzing repo which as been migrated to the main repo. I cut the line entirely, but it may make more sense to update to mention the old repo has been moved, in case legacy users read and did not know.