### PR TITLE
fix indentation in example provider config

### DIFF
--- a/tools/cloudlist/running.mdx
+++ b/tools/cloudlist/running.mdx
@@ -186,18 +186,18 @@ The default provider config file should be located at `$HOME/.config/cloudlist/p
   # consul_http_auth: <consul-http-auth-value>
 
 - provider: openstack # provider is the name of the provider
- # id is the name of the provider id
- id: staging
- # identity_endpoint is OpenStack identity endpoint used to authenticate
- identity_endpoint: $OS_IDENTITY_ENDPOINT
- # domain_name is OpenStack domain name used to authenticate
- domain_name: $OS_DOMAIN_NAME
- # tenant_name is OpenStack project name
- tenant_name: $OS_TENANT_NAME
- # username is OpenStack username used to authenticate
- username: $OS_USERNAME
- # password is OpenStack password used to authenticate
- password: $OS_PASSWORD
+  # id is the name of the provider id
+  id: staging
+  # identity_endpoint is OpenStack identity endpoint used to authenticate
+  identity_endpoint: $OS_IDENTITY_ENDPOINT
+  # domain_name is OpenStack domain name used to authenticate
+  domain_name: $OS_DOMAIN_NAME
+  # tenant_name is OpenStack project name
+  tenant_name: $OS_TENANT_NAME
+  # username is OpenStack username used to authenticate
+  username: $OS_USERNAME
+  # password is OpenStack password used to authenticate
+  password: $OS_PASSWORD
 
 - provider: kubernetes # provider is the name of the provider
   # id is the name of the provider id


### PR DESCRIPTION
Current example provider config lacks some indentation causing Cloudlist failure when using it as is:

```
cloudlist -provider aws

  _______             _____     __
 / ___/ /__  __ _____/ / (_)__ / /_
/ /__/ / _ \/ // / _  / / (_-</ __/
\___/_/\___/\_,_/\_,_/_/_/___/\__/

                projectdiscovery.io

[INF] Current cloudlist version 1.1.0 (latest)
[FTL] Could not create runner: invalid provider configuration file provided
```