### PR TITLE
Update oob-testing.mdx

### DIFF
--- a/templates/reference/oob-testing.mdx
+++ b/templates/reference/oob-testing.mdx
@@ -71,5 +71,5 @@ matchers:
     - type: regex
       part: interactsh_request # Confirms the retrieval of /etc/passwd file
       regex:
-        - "root:[x*]:0:0:"
+        - 'root:.*:0:0:'
 ```


### PR DESCRIPTION
[x*] → Character class: Matches either x or *, but not both together. It does not match any sequence of characters between root: and :0:0:, only x or *. 
.* → Matches any number of characters (including none) between root: and :0:0:. This is more flexible than [x*].
Also, 
Single quotes prevent YAML from misinterpreting special characters like *, . or :.