### PR TITLE
fix $HOME path variable

### DIFF
--- a/tools/subfinder/install.mdx
+++ b/tools/subfinder/install.mdx
@@ -59,11 +59,11 @@ sidebarTitle: "Install"
  - Subfinder requires the latest version of [**Go**](https://go.dev/doc/install)
  -  Add the Go bin path to the system paths. On OSX or Linux, in your terminal use
  ```
- echo export PATH=$PATH:$HOME/go/bin >> $home/.bashrc
- source $home/.bashrc
+ echo export PATH=$PATH:$HOME/go/bin >> $HOME/.bashrc
+ source $HOME/.bashrc
  ```
  - To add the path in Windows, [click this link for instructions.](https://www.architectryan.com/2018/03/17/add-to-the-path-on-windows-10/)
- - The binary will be located in `$home/go/bin/subfinder`  
+ - The binary will be located in `$HOME/go/bin/subfinder`  
 
 ## Post install configuration
 


### PR DESCRIPTION
Under regular *nix distributions, home is stored in uppercase $HOME variable