### PR TITLE
Fixed a typo in pdtm page

### DIFF
--- a/tools/pdtm/install.mdx
+++ b/tools/pdtm/install.mdx
@@ -27,4 +27,4 @@ sidebarTitle: Install
 ## Installation Notes
   - PDTM requires the latest version of [**Go**](https://go.dev/doc/install)
   - Projects are installed by downloading the released project binary. This means that projects can only be installed on the platforms for which binaries have been published.
-  - The path $HOME/.pdtm/go/bin is added to the $PATH variable by default
+  - The path \$HOME/.pdtm/go/bin is added to the \$PATH variable by default

--- a/tools/pdtm/install.mdx
+++ b/tools/pdtm/install.mdx
@@ -27,4 +27,4 @@ sidebarTitle: Install
 ## Installation Notes
   - PDTM requires the latest version of [**Go**](https://go.dev/doc/install)
   - Projects are installed by downloading the released project binary. This means that projects can only be installed on the platforms for which binaries have been published.
-  - The path \$HOME/.pdtm/go/bin is added to the \$PATH variable by default
+  - The path `$HOME/.pdtm/go/bin` is added to the `$PATH` variable by default


### PR DESCRIPTION
escaped $ sign properly which was previously being treated as LaTeX math
<img width="755" height="257" alt="image" src="https://github.com/user-attachments/assets/a57a83a3-3707-4f41-a9d3-fabc787bc68a" />
