### PR TITLE
Change JQ link to gojq in extractors documentation

### DIFF
--- a/templates/reference/extractors.mdx
+++ b/templates/reference/extractors.mdx
@@ -55,7 +55,7 @@ A **json** extractor example to extract value of `id` object from JSON block.
           - '.[] | .id'  # JQ like syntax for extraction
 ```
 
-For more details about JQ - https://github.com/stedolan/jq
+For more details about JQ - https://github.com/itchyny/gojq
 
 ### Xpath Extractor
 


### PR DESCRIPTION
gojq has some specific differences compared to jq and is what is actually used inside of Nuclei.