### PR TITLE
Update leaks API documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /static/docsbuilder/node_modules/
 /static/docsbuilder/src/
 CLAUDE.md
+filter_openapi.py

--- a/api-reference/leaks/export-leaks.mdx
+++ b/api-reference/leaks/export-leaks.mdx
@@ -1,0 +1,130 @@
+---
+openapi: post /v1/leaks/export
+---
+
+## Overview
+
+Export leaked credentials data with the same filtering capabilities as the main leaks endpoint. Supports both JSON and CSV formats for easy integration with external tools and reporting systems.
+
+## Export Formats
+
+### JSON Format
+Returns structured data identical to the GET `/v1/leaks` endpoint response.
+
+### CSV Format  
+Returns comma-separated values with headers, perfect for spreadsheet applications and data analysis tools.
+
+## Request Body
+
+The export endpoint accepts the same filtering parameters as the GET `/v1/leaks` endpoint in the request body:
+
+```json
+{
+  "type": "all",
+  "domain": "example.com", 
+  "email": "user@example.com",
+  "search": "facebook",
+  "limit": 1000,
+  "page_number": 1,
+  "start_date": "2023-01-01",
+  "end_date": "2023-12-31",
+  "time_range": "last_6_months",
+  "sort_by": "log_date",
+  "sort_order": "desc",
+  "status": "open",
+  "group_by": "url"
+}
+```
+
+## Response Examples
+
+### JSON Export Response
+```json
+{
+  "data": [
+    {
+      "id": "leak_id_hash",
+      "url": "https://example.com",
+      "username": "user@example.com", 
+      "password": "masked_password",
+      "device_ip": "192.168.1.1",
+      "hostname": "DESKTOP-ABC123",
+      "os": "Windows 10",
+      "country": "United States",
+      "log_date": "2023-01-15",
+      "hardware_id": "hw_12345",
+      "domain": "example.com",
+      "email_domain": "example.com",
+      "url_domain": "example.com",
+      "status": "open",
+      "user_type": "employee"
+    }
+  ],
+  "total_leaks": 150,
+  "summary": {
+    "total_leaks": 150,
+    "personal_leaks": 25,
+    "employee_leaks": 100,
+    "customer_leaks": 25
+  }
+}
+```
+
+### CSV Export Response
+```csv
+id,url,username,password,device_ip,hostname,os,country,log_date,hardware_id,domain,email_domain,url_domain,status,user_type
+leak_id_hash,https://example.com,user@example.com,masked_password,192.168.1.1,DESKTOP-ABC123,Windows 10,United States,2023-01-15,hw_12345,example.com,example.com,example.com,open,employee
+```
+
+## Usage Examples
+
+### Export all leaks as JSON
+```bash
+curl -X POST "https://api.projectdiscovery.io/v1/leaks/export?format=json" \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "type": "all"
+  }'
+```
+
+### Export employee leaks as CSV
+```bash
+curl -X POST "https://api.projectdiscovery.io/v1/leaks/export?format=csv" \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "type": "employee",
+    "domain": "mycompany.com"
+  }'
+```
+
+### Export with date filtering
+```bash
+curl -X POST "https://api.projectdiscovery.io/v1/leaks/export" \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "time_range": "last_3_months",
+    "status": "open",
+    "sort_by": "log_date",
+    "sort_order": "desc"
+  }'
+```
+
+## Best Practices
+
+### Large Datasets
+- Use pagination (`limit` and `page_number`) for large exports
+- Consider filtering by date ranges to reduce response size
+- CSV format is more efficient for large datasets
+
+### Security Considerations
+- Exported data may contain sensitive information
+- Ensure secure handling and storage of exported files
+- Password unmasking follows the same ACL rules as the main leaks endpoint
+
+### Performance Tips
+- Use specific filters to reduce export size
+- CSV exports are generally faster for large datasets
+- Consider using `group_by` for summary reports instead of full exports

--- a/api-reference/leaks/get-all-leaks.mdx
+++ b/api-reference/leaks/get-all-leaks.mdx
@@ -1,0 +1,140 @@
+---
+openapi: get /v1/leaks
+---
+
+<Info>
+This is the **new consolidated leaks endpoint** that replaces the deprecated individual endpoints (`/v1/leaks/domain`, `/v1/leaks/email`, `/v1/leaks/domain/customers`).
+
+It returns all types of leaks (personal, employee, customer) with optional filtering by type.
+</Info>
+
+## Overview
+
+The consolidated leaks endpoint provides access to all leaked credentials associated with your account:
+
+- **Personal leaks**: Leaks associated with your personal email address
+- **Employee leaks**: Leaks from employees of your verified domains, classified as:
+  - `organization_leaks`: Leaks on organization systems (login URL domain matches email domain)
+  - `external_vendor_leaks`: Leaks on external vendor systems (login URL domain differs from email domain)
+- **Customer leaks**: Leaks from customers using your verified domains
+
+## Key Features
+
+### Advanced Filtering
+- Filter by leak type (`personal`, `employee`, `customer`, `external_vendor_leaks`, `organization_leaks`)
+- Search across all fields
+- Filter by domain, email, status, and date ranges
+- Sort by various fields (URL, username, log_date, country, etc.)
+
+### Grouping & Analytics
+Use the `group_by` parameter to get aggregated data:
+- Group by URL, country, device_ip, hostname, email, or hardware_id
+- Returns group summaries instead of individual leak records
+- Perfect for analytics and reporting
+
+### Pagination
+- Standard pagination with `limit` and `page_number` parameters
+- Default limit: 20 results per page
+
+## Response Structure
+
+### Individual Leaks Response
+```json
+{
+  "data": [
+    {
+      "id": "leak_id_hash",
+      "url": "https://example.com",
+      "username": "user@example.com",
+      "password": "masked_or_unmasked",
+      "device_ip": "192.168.1.1",
+      "hostname": "DESKTOP-ABC123",
+      "os": "Windows 10",
+      "country": "United States",
+      "log_date": "2023-01-15",
+      "hardware_id": "hw_12345",
+      "domain": "example.com",
+      "email_domain": "example.com",
+      "url_domain": "example.com",
+      "status": "open",
+      "user_type": "employee"
+    }
+  ],
+  "total_leaks": 150,
+  "total_pages": 8,
+  "total_count": 150,
+  "summary": {
+    "total_leaks": 150,
+    "personal_leaks": 25,
+    "employee_leaks": 100,
+    "customer_leaks": 25,
+    "external_vendor_leaks": 60,
+    "organization_leaks": 40
+  }
+}
+```
+
+### Grouped Response (when using `group_by`)
+```json
+{
+  "group_summary": [
+    {
+      "url": "https://facebook.com",
+      "count": 45
+    },
+    {
+      "url": "https://linkedin.com", 
+      "count": 32
+    }
+  ],
+  "total_leaks": 150
+}
+```
+
+## Privacy & Security
+
+### Access Control
+- **Personal leaks**: Always accessible to the authenticated user
+- **Employee/Customer leaks**: Requires domain verification
+- **Password unmasking**: Requires domain verification
+
+### Data Classification
+The API automatically classifies employee leaks:
+- **Organization leaks**: Login URL domain matches or is a subdomain of the email domain
+- **External vendor leaks**: Login URL domain is completely different from email domain
+
+## Migration from Deprecated Endpoints
+
+If you're currently using the deprecated endpoints, here's how to migrate:
+
+| Deprecated Endpoint | New Equivalent |
+|-------------------|----------------|
+| `GET /v1/leaks/email` | `GET /v1/leaks?type=personal` |
+| `GET /v1/leaks/domain` | `GET /v1/leaks?type=employee` |
+| `GET /v1/leaks/domain/customers` | `GET /v1/leaks?type=customer` |
+
+## Examples
+
+### Get all leaks
+```bash
+curl -X GET "https://api.projectdiscovery.io/v1/leaks" \
+  -H "Authorization: Bearer YOUR_API_KEY"
+```
+
+### Get only employee leaks
+```bash
+curl -X GET "https://api.projectdiscovery.io/v1/leaks?type=employee" \
+  -H "Authorization: Bearer YOUR_API_KEY"
+```
+
+### Get leaks grouped by URL
+```bash
+curl -X GET "https://api.projectdiscovery.io/v1/leaks?group_by=url" \
+  -H "Authorization: Bearer YOUR_API_KEY"
+```
+
+### Search for specific domain
+```bash
+curl -X GET "https://api.projectdiscovery.io/v1/leaks?domain=example.com" \
+  -H "Authorization: Bearer YOUR_API_KEY"
+```

--- a/api-reference/leaks/get-domain-customer-leaks.mdx
+++ b/api-reference/leaks/get-domain-customer-leaks.mdx
@@ -1,3 +1,47 @@
 ---
 openapi: get /v1/leaks/domain/customers
 ---
+
+<Warning>
+**DEPRECATED:** This endpoint is deprecated in favor of the consolidated `/v1/leaks` endpoint.
+
+Use `GET /v1/leaks?type=customer` instead for the same functionality with enhanced features.
+</Warning>
+
+## Migration Guide
+
+This endpoint has been replaced by the new consolidated leaks API. Here's how to migrate:
+
+### Old Way (Deprecated)
+```bash
+GET /v1/leaks/domain/customers?search=example&limit=20
+```
+
+### New Way (Recommended)
+```bash
+GET /v1/leaks?type=customer&search=example&limit=20
+```
+
+## Why Migrate?
+
+The new consolidated endpoint offers several advantages:
+
+- **Unified API**: Access all leak types (personal, employee, customer) from one endpoint
+- **Enhanced Privacy**: Better privacy controls for customer data
+- **Advanced Filtering**: More sophisticated filtering and search capabilities
+- **Improved Performance**: Optimized for better response times
+- **Future-Proof**: All new features will be added to the consolidated endpoint
+- **Better Analytics**: Enhanced grouping and summary capabilities
+
+## Privacy Enhancements
+
+The new consolidated endpoint includes enhanced privacy protections for customer leaks:
+
+- **Password Masking**: Customer leak passwords are never unmasked (privacy protection)
+- **Access Control**: Stricter validation of domain ownership
+- **Audit Logging**: Better tracking of access to customer data
+
+## See Also
+
+- [Get All Leaks (New Consolidated Endpoint)](/api-reference/leaks/get-all-leaks)
+- [Migration Guide](#migration-guide) above

--- a/api-reference/leaks/get-domain-leaks.mdx
+++ b/api-reference/leaks/get-domain-leaks.mdx
@@ -1,3 +1,38 @@
 ---
 openapi: get /v1/leaks/domain
 ---
+
+<Warning>
+**DEPRECATED:** This endpoint is deprecated in favor of the consolidated `/v1/leaks` endpoint.
+
+Use `GET /v1/leaks?type=employee` instead for the same functionality with enhanced features.
+</Warning>
+
+## Migration Guide
+
+This endpoint has been replaced by the new consolidated leaks API. Here's how to migrate:
+
+### Old Way (Deprecated)
+```bash
+GET /v1/leaks/domain?search=example&limit=20
+```
+
+### New Way (Recommended)
+```bash
+GET /v1/leaks?type=employee&search=example&limit=20
+```
+
+## Why Migrate?
+
+The new consolidated endpoint offers several advantages:
+
+- **Unified API**: Access all leak types (personal, employee, customer) from one endpoint
+- **Enhanced Classification**: Distinguishes between organization leaks and external vendor leaks
+- **Better Filtering**: More advanced filtering and grouping options
+- **Improved Performance**: Optimized for better response times
+- **Future-Proof**: All new features will be added to the consolidated endpoint
+
+## See Also
+
+- [Get All Leaks (New Consolidated Endpoint)](/api-reference/leaks/get-all-leaks)
+- [Migration Guide](#migration-guide) above

--- a/api-reference/leaks/get-domain-stats.mdx
+++ b/api-reference/leaks/get-domain-stats.mdx
@@ -1,0 +1,85 @@
+---
+openapi: get /v1/leaks/stats/domain
+---
+
+## Overview
+
+Get statistical information about leaks associated with a specific domain. This endpoint provides aggregate data for monitoring and reporting purposes.
+
+<Info>
+This endpoint requires domain verification. You can only get stats for domains you have verified ownership of.
+</Info>
+
+## Query Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `domain` | string | **Required.** The domain to get leak statistics for |
+| `unmask_email` | boolean | Whether to unmask email addresses in the response |
+
+## Response Structure
+
+The response provides comprehensive statistics about leaks for the specified domain:
+
+```json
+{
+  "domain": "example.com",
+  "total_leaks": 150,
+  "open_leaks": 120,
+  "fixed_leaks": 30,
+  "leak_types": {
+    "employee_leaks": 100,
+    "customer_leaks": 50
+  },
+  "recent_activity": {
+    "last_30_days": 15,
+    "last_7_days": 3
+  },
+  "top_services": [
+    {
+      "service": "facebook.com",
+      "count": 45
+    },
+    {
+      "service": "linkedin.com", 
+      "count": 32
+    }
+  ],
+  "geographic_distribution": [
+    {
+      "country": "United States",
+      "count": 89
+    },
+    {
+      "country": "Canada",
+      "count": 23
+    }
+  ]
+}
+```
+
+## Usage Examples
+
+### Get basic domain stats
+```bash
+curl -X GET "https://api.projectdiscovery.io/v1/leaks/stats/domain?domain=example.com" \
+  -H "Authorization: Bearer YOUR_API_KEY"
+```
+
+### Get stats with unmasked emails
+```bash
+curl -X GET "https://api.projectdiscovery.io/v1/leaks/stats/domain?domain=example.com&unmask_email=true" \
+  -H "Authorization: Bearer YOUR_API_KEY"
+```
+
+## Best Practices
+
+### Regular Monitoring
+- Check domain stats regularly to identify new leaks quickly
+- Set up automated alerts when leak counts increase
+- Monitor the ratio of open vs fixed leaks
+
+### Performance Considerations
+- Cache stats data appropriately to avoid excessive API calls
+- Use this endpoint for summary data, detailed leak info requires other endpoints
+- Consider rate limiting when building automated monitoring systems

--- a/api-reference/leaks/get-email-leaks.mdx
+++ b/api-reference/leaks/get-email-leaks.mdx
@@ -1,3 +1,38 @@
 ---
 openapi: get /v1/leaks/email
 ---
+
+<Warning>
+**DEPRECATED:** This endpoint is deprecated in favor of the consolidated `/v1/leaks` endpoint.
+
+Use `GET /v1/leaks?type=personal` instead for the same functionality with enhanced features.
+</Warning>
+
+## Migration Guide
+
+This endpoint has been replaced by the new consolidated leaks API. Here's how to migrate:
+
+### Old Way (Deprecated)
+```bash
+GET /v1/leaks/email?search=example&limit=20
+```
+
+### New Way (Recommended)
+```bash
+GET /v1/leaks?type=personal&search=example&limit=20
+```
+
+## Why Migrate?
+
+The new consolidated endpoint offers several advantages:
+
+- **Unified API**: Access all leak types (personal, employee, customer) from one endpoint
+- **Enhanced Features**: Better filtering, grouping, and analytics capabilities
+- **Improved Performance**: Optimized for better response times and reliability
+- **Future-Proof**: All new features will be added to the consolidated endpoint
+- **Better Integration**: Easier to build comprehensive security dashboards
+
+## See Also
+
+- [Get All Leaks (New Consolidated Endpoint)](/api-reference/leaks/get-all-leaks)
+- [Migration Guide](#migration-guide) above

--- a/api-reference/leaks/get-email-stats.mdx
+++ b/api-reference/leaks/get-email-stats.mdx
@@ -1,0 +1,120 @@
+---
+openapi: get /v1/leaks/stats/email
+---
+
+## Overview
+
+Get statistical information about leaks associated with a specific email address. This endpoint provides aggregate data for personal leak monitoring and analysis.
+
+<Info>
+This endpoint is primarily used for personal email leak statistics. For organizational monitoring, consider using the domain stats endpoint instead.
+</Info>
+
+## Query Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `email` | string | **Required.** The email address to get leak statistics for |
+| `unmask_email` | boolean | Whether to unmask email addresses in the response |
+
+## Response Structure
+
+The response provides comprehensive statistics about leaks for the specified email:
+
+```json
+{
+  "email": "user@example.com",
+  "total_leaks": 25,
+  "open_leaks": 18,
+  "fixed_leaks": 7,
+  "leak_classification": {
+    "personal_leaks": 15,
+    "employee_leaks": 8,
+    "customer_leaks": 2
+  },
+  "recent_activity": {
+    "last_30_days": 3,
+    "last_7_days": 1
+  },
+  "compromised_services": [
+    {
+      "service": "facebook.com",
+      "count": 8,
+      "last_seen": "2023-03-15T10:30:00Z"
+    },
+    {
+      "service": "linkedin.com",
+      "count": 5,
+      "last_seen": "2023-02-28T14:20:00Z"
+    }
+  ],
+  "risk_timeline": [
+    {
+      "date": "2023-03",
+      "new_leaks": 3,
+      "fixed_leaks": 1
+    },
+    {
+      "date": "2023-02", 
+      "new_leaks": 5,
+      "fixed_leaks": 2
+    }
+  ]
+}
+```
+
+## Data Fields Explained
+
+| Field | Description |
+|-------|-------------|
+| `email` | The email address these statistics apply to |
+| `total_leaks` | Total number of leaks found for this email |
+| `open_leaks` | Number of leaks that haven't been marked as fixed |
+| `fixed_leaks` | Number of leaks marked as remediated |
+| `leak_classification` | Breakdown by leak type (personal, employee, customer) |
+| `recent_activity` | New leak discovery in recent time periods |
+| `compromised_services` | Services where this email was found in leaks |
+| `risk_timeline` | Historical trend of leak discovery and remediation |
+
+## Usage Examples
+
+### Get basic email stats
+```bash
+curl -X GET "https://api.projectdiscovery.io/v1/leaks/stats/email?email=user@example.com" \
+  -H "Authorization: Bearer YOUR_API_KEY"
+```
+
+### Get stats with unmasked emails
+```bash
+curl -X GET "https://api.projectdiscovery.io/v1/leaks/stats/email?email=user@example.com&unmask_email=true" \
+  -H "Authorization: Bearer YOUR_API_KEY"
+```
+
+## Privacy Considerations
+
+### Access Control
+- You can only access stats for emails you're authorized to view
+- Personal emails: accessible to the account owner
+- Employee emails: requires domain verification
+
+### Data Sensitivity
+- Email statistics may reveal sensitive information about user behavior
+- Consider data retention policies for stored statistics
+- Implement appropriate access controls in your applications
+
+## Best Practices
+
+### Regular Monitoring
+- Check email stats periodically for accounts under your management
+- Set up alerts for new leak discoveries
+- Track remediation progress to ensure security improvements
+
+### Integration Tips
+- Use this endpoint for summary dashboards and reports
+- Combine with detailed leak endpoints for comprehensive security monitoring
+- Cache results appropriately to minimize API usage
+
+### Security Recommendations
+- Encourage users to fix open leaks promptly
+- Provide guidance on changing passwords for compromised services
+- Monitor trends to identify systemic security issues

--- a/api-reference/leaks/get-leak-info.mdx
+++ b/api-reference/leaks/get-leak-info.mdx
@@ -1,0 +1,136 @@
+---
+openapi: post /v1/leaks/info
+---
+
+## Overview
+
+Retrieve detailed information for a specific leak by its ID. This endpoint provides access to complete leak details with optional password and email unmasking based on your permissions and domain verification.
+
+## Authentication & Authorization
+
+### Access Control
+- **Personal leaks**: Always accessible if the leak belongs to your email
+- **Employee/Customer leaks**: Requires domain verification for the associated domain
+- **Password unmasking**: Requires domain verification
+- **Customer leak privacy**: Passwords are never unmasked for customer leaks (privacy protection)
+
+### Leak ID Format
+The leak ID must be a 32-character MD5 hash (e.g., `b3652f2555841f7652badd9804859f4e`).
+
+## Request Body
+
+```json
+{
+  "leakid": "b3652f2555841f7652badd9804859f4e"
+}
+```
+
+## Response Examples
+
+### Successful Response
+```json
+{
+  "success": true,
+  "data": {
+    "id": "b3652f2555841f7652badd9804859f4e",
+    "url": "https://facebook.com/login",
+    "username": "john.doe@example.com",
+    "password": "mypassword123",
+    "device_ip": "192.168.1.100",
+    "hostname": "JOHN-LAPTOP",
+    "os": "Windows 10 Pro",
+    "malware_path": "C:\\Users\\John\\AppData\\Roaming\\malware.exe",
+    "country": "United States",
+    "log_date": "2023-03-15T10:30:00Z",
+    "hardware_id": "HW-ABC123DEF456",
+    "domain": "example.com",
+    "email_domain": "example.com",
+    "fetched_at": "2023-03-16T08:00:00Z",
+    "status": "open"
+  }
+}
+```
+
+### Error Responses
+
+#### Invalid Leak ID Format
+```json
+{
+  "success": false,
+  "message": "Invalid leak ID format"
+}
+```
+
+#### Leak Not Found
+```json
+{
+  "success": false,
+  "message": "Leak not found"
+}
+```
+
+#### Access Denied
+```json
+{
+  "message": "Access denied: you don't have access to this leak"
+}
+```
+
+## Data Fields Explained
+
+| Field | Description |
+|-------|-------------|
+| `id` | Unique 32-character MD5 hash identifier |
+| `url` | The website/service where credentials were compromised |
+| `username` | Username or email address (always unmasked if authorized) |
+| `password` | Password (masked/unmasked based on permissions) |
+| `device_ip` | IP address of the compromised device |
+| `hostname` | Computer/device hostname |
+| `os` | Operating system information |
+| `malware_path` | File path of the malware that captured the credentials |
+| `country` | Geographic location of the compromise |
+| `log_date` | When the credentials were captured |
+| `hardware_id` | Unique hardware identifier |
+| `domain` | Domain associated with this leak (for filtering) |
+| `email_domain` | Domain extracted from the email address |
+| `fetched_at` | When this leak was discovered/indexed |
+| `status` | Current status (`open` or `fixed`) |
+
+## Password Unmasking Rules
+
+### When Passwords Are Unmasked
+- Personal leaks: Always unmasked for the account owner
+- Employee leaks: Unmasked with domain verification
+- Customer leaks: **Never unmasked** (privacy protection)
+
+### When Passwords Are Masked
+- Shows as `***MASKED***` when access is not authorized
+- Customer leak passwords are always masked for privacy protection
+
+## Usage Examples
+
+### Get leak information
+```bash
+curl -X POST "https://api.projectdiscovery.io/v1/leaks/info" \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "leakid": "b3652f2555841f7652badd9804859f4e"
+  }'
+```
+
+## Security Considerations
+
+### Privacy Protection
+- Customer leak passwords are never exposed to maintain customer privacy
+- Access is strictly controlled based on domain verification
+- All access attempts are logged for security auditing
+
+### Data Sensitivity
+- Leak information contains sensitive credential data
+- Ensure secure handling and storage of retrieved information
+- Consider implementing additional encryption for stored leak details
+
+### Rate Limiting
+- This endpoint may have rate limits to prevent abuse
+- Implement proper error handling for rate limit responses

--- a/api-reference/leaks/update-leak-status.mdx
+++ b/api-reference/leaks/update-leak-status.mdx
@@ -1,0 +1,168 @@
+---
+openapi: post /v1/leaks/status
+---
+
+## Overview
+
+Update the status of one or more leaks to track remediation progress. You can mark leaks as `fixed` when credentials have been changed or `open` if they need attention.
+
+## Authentication & Authorization
+
+### Access Control
+- **Personal leaks**: Always accessible if the leak belongs to your email
+- **Employee/Customer leaks**: Requires domain verification for the associated domain
+- **Bulk operations**: All specified leaks must be accessible to your account
+
+### Privacy-First Validation
+The API validates leak ownership before allowing status updates to ensure users can only modify leaks they have access to.
+
+## Request Body
+
+You can update a single leak or multiple leaks in one request:
+
+### Single Leak Update
+```json
+{
+  "leakid": "b3652f2555841f7652badd9804859f4e",
+  "status": "fixed"
+}
+```
+
+### Multiple Leaks Update
+```json
+{
+  "leakids": [
+    "b3652f2555841f7652badd9804859f4e",
+    "c4763g3666952g8763caee0915960g5f",
+    "d5874h4777063h9874dbff1026071h6g"
+  ],
+  "status": "fixed"
+}
+```
+
+## Status Values
+
+| Status | Description |
+|--------|-------------|
+| `open` | Leak requires attention - credentials may still be compromised |
+| `fixed` | Leak has been remediated - credentials have been changed/secured |
+
+## Response Examples
+
+### Successful Update
+```json
+{
+  "status": "success",
+  "message": "Leak status updated successfully",
+  "leak_id": "b3652f2555841f7652badd9804859f4e",
+  "new_status": "fixed"
+}
+```
+
+### Bulk Update Success
+```json
+{
+  "status": "success", 
+  "message": "3 leak statuses updated successfully",
+  "updated_count": 3
+}
+```
+
+### Error Responses
+
+#### Invalid Request Body
+```json
+{
+  "message": "Invalid request body"
+}
+```
+
+#### Access Denied
+```json
+{
+  "message": "Access denied: you don't have access to this leak"
+}
+```
+
+#### Leak Not Found
+```json
+{
+  "message": "One or more leaks not found"
+}
+```
+
+## Validation Rules
+
+### Required Fields
+- Either `leakid` (single) OR `leakids` (multiple) must be provided
+- `status` field is required and must be either `"open"` or `"fixed"`
+
+### Leak ID Format
+- Must be 32-character MD5 hash (e.g., `b3652f2555841f7652badd9804859f4e`)
+- Invalid format will result in a 400 error
+
+### Ownership Validation
+- API validates that you have access to each leak before updating
+- Unauthorized leaks will result in a 403 error
+
+## Usage Examples
+
+### Mark single leak as fixed
+```bash
+curl -X POST "https://api.projectdiscovery.io/v1/leaks/status" \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "leakid": "b3652f2555841f7652badd9804859f4e",
+    "status": "fixed"
+  }'
+```
+
+### Mark multiple leaks as fixed
+```bash
+curl -X POST "https://api.projectdiscovery.io/v1/leaks/status" \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "leakids": [
+      "b3652f2555841f7652badd9804859f4e",
+      "c4763g3666952g8763caee0915960g5f"
+    ],
+    "status": "fixed"
+  }'
+```
+
+### Reopen a previously fixed leak
+```bash
+curl -X POST "https://api.projectdiscovery.io/v1/leaks/status" \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "leakid": "b3652f2555841f7652badd9804859f4e",
+    "status": "open"
+  }'
+```
+
+## Best Practices
+
+### Remediation Workflow
+1. **Identify leaks** using the main leaks endpoint
+2. **Get detailed info** using the leak info endpoint
+3. **Change credentials** on the affected service
+4. **Mark as fixed** using this status endpoint
+5. **Monitor for new leaks** regularly
+
+### Bulk Operations
+- Use bulk updates when fixing multiple related leaks
+- Validate all leak IDs before making bulk requests
+- Handle partial failures gracefully in bulk operations
+
+### Status Management
+- Mark leaks as `fixed` only after confirming credential changes
+- Use `open` status to flag leaks that need immediate attention
+- Regularly audit fixed leaks to ensure they remain secure
+
+### Error Handling
+- Implement retry logic for transient failures
+- Log access denied errors for security monitoring
+- Validate leak ID format before making requests

--- a/mint.json
+++ b/mint.json
@@ -513,9 +513,12 @@
         {
           "group": "Leaks",
           "pages": [
-            "api-reference/leaks/get-domain-leaks",
-            "api-reference/leaks/get-email-leaks",
-            "api-reference/leaks/get-domain-customer-leaks"
+            "api-reference/leaks/get-all-leaks",
+            "api-reference/leaks/export-leaks",
+            "api-reference/leaks/get-leak-info",
+            "api-reference/leaks/update-leak-status",
+            "api-reference/leaks/get-domain-stats",
+            "api-reference/leaks/get-email-stats"
           ]
         },
         {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -119,6 +119,114 @@ paths:
       - X-API-Key: []
       description: Search templates with filtering, sorting, and faceting capabilities
       operationId: get-v2-template-search
+  /v2/template/user/upload:
+    post:
+      summary: Upload Templates
+      tags: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                - insert_errors
+                - total_files
+                - not_templates
+                - inserted
+                - invalid_templates
+                properties:
+                  insert_errors:
+                    type: integer
+                  total_files:
+                    type: integer
+                  not_templates:
+                    type: integer
+                  inserted:
+                    type: integer
+                  invalid_templates:
+                    type: integer
+                  templates:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/TemplateData'
+        '400':
+          $ref: '#/components/responses/MessageResponse'
+        '401':
+          $ref: '#/components/responses/MessageResponse'
+        '404':
+          $ref: '#/components/responses/MessageResponse'
+        '500':
+          $ref: '#/components/responses/MessageResponse'
+        default:
+          $ref: '#/components/responses/MessageResponse'
+      operationId: post-v2-template-user-upload
+      description: Upload Private/User Templates (Max 10,000)
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - templates
+              properties:
+                templates:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/UploadTemplate'
+    patch:
+      summary: Bulk Update User Template
+      tags: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                - success_count
+                - failure_count
+                - successful_items
+                - failed_items
+                properties:
+                  success_count:
+                    type: integer
+                  failure_count:
+                    type: integer
+                  successful_items:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/TemplateFileMetadata'
+                  failed_items:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/FailedTemplateFileMetadataUpdate'
+        '400':
+          $ref: '#/components/responses/MessageResponse'
+        '401':
+          $ref: '#/components/responses/MessageResponse'
+        '404':
+          $ref: '#/components/responses/MessageResponse'
+        '500':
+          $ref: '#/components/responses/MessageResponse'
+        default:
+          $ref: '#/components/responses/MessageResponse'
+      operationId: patch-v2-template-user-upload
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - templates
+              properties:
+                templates:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/PatchTemplateFileMetadata'
+      description: Bulk Updat Private/User Templates (Max 10,000)
   /v1/scans:
     get:
       summary: Get Scan List
@@ -161,8 +269,7 @@ paths:
           type: string
         in: query
         name: status
-        description: filter by status (failed, finished, queued, running, starting,
-          uploaded, scheduled)
+        description: filter by status (failed, finished, queued, running, starting, uploaded, scheduled)
       - schema:
           type: string
         in: query
@@ -367,6 +474,15 @@ paths:
         in: header
         description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
         name: X-Team-Id
+  /v1/admin/team/change_owner:
+    parameters:
+    - in: header
+      name: X-Team-ID
+      required: true
+      schema:
+        type: string
+  /v1/admin/scan/token:
+    parameters: []
   /v1/scans/{scan_id}/stop:
     parameters:
     - schema:
@@ -464,6 +580,106 @@ paths:
       in: path
       required: true
       description: vulnerability ID
+  /v1/scans/result/{scanId}:
+    get:
+      summary: Get Scan Results
+      tags:
+      - results
+      responses:
+        '200':
+          $ref: '#/components/responses/GetScanResultsResponse'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '499':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v1-scans-result-:scanId
+      description: get results of specific scan by id
+      security:
+      - X-API-Key: []
+      parameters:
+      - schema:
+          type: string
+        in: query
+        name: severity
+        description: comma separated severity e.g. severity=info,high
+      - schema:
+          type: string
+        in: query
+        name: search
+        description: search term
+      - schema:
+          type: integer
+        in: query
+        name: limit
+        description: 'number of results '
+      - schema:
+          type: integer
+        in: query
+        name: offset
+        description: number of results to skip
+      - schema:
+          type: string
+        in: query
+        name: templates
+        description: comma separated templates e.g. templates=tech-detect,azure-takeover
+      - schema:
+          type: string
+        in: query
+        name: hosts
+        description: comma separated host e.g. hosts=https://example.com,https://x.com
+      - in: query
+        name: domain
+        schema:
+          type: string
+        description: comma separated domain names e.g-> domain=domain1.com,domain2.com
+      - in: query
+        name: port
+        schema:
+          type: string
+        description: comma separated ports e.g. ports=80,443
+      - schema:
+          type: string
+        in: query
+        description: filter by time ( last_day, last_week, last_month )
+        name: time
+      - schema:
+          type: string
+        in: query
+        name: vuln_status
+        description: comma separated vuln_status e.g vuln_status=open,fixed
+      - schema:
+          type: string
+        in: query
+        name: sort_asc
+        description: comma separated ascending sorting e.g sort_asc=created_at,severity
+      - schema:
+          type: string
+        in: query
+        name: sort_desc
+        description: comma separated descending sorting e.g sort_desc=created_at,severity
+      - schema:
+          type: boolean
+        in: query
+        name: asset_metadata
+        description: Asset details for the vulnerability
+      - schema:
+          type: string
+        in: header
+        name: X-Team-Id
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+    parameters:
+    - schema:
+        type: string
+      name: scanId
+      in: path
+      required: true
+      description: scan specific results (by scanId)
   /v1/scans/vuln/{vuln_id}/changelogs:
     get:
       summary: Get Vulnerability Changelogs
@@ -605,6 +821,153 @@ paths:
         in: header
         name: X-Team-Id
         description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+  /v1/scans/results:
+    get:
+      summary: Get All Results
+      tags:
+      - results
+      responses:
+        '200':
+          $ref: '#/components/responses/GetScanResultsResponse'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '499':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v1-results
+      description: Get scans results of a user
+      parameters:
+      - schema:
+          type: integer
+        in: query
+        name: offset
+        description: number of results to skip
+      - schema:
+          type: integer
+        in: query
+        name: limit
+        description: number of results to get
+      - schema:
+          type: string
+        in: query
+        name: severity
+        description: string separated by comma e.g. info,high
+      - schema:
+          type: string
+        in: query
+        name: search
+        description: search term
+      - schema:
+          type: string
+        in: query
+        name: host
+        description: comma separated host e.g. hosts=https://example.com,https://x.com
+      - in: query
+        name: domain
+        schema:
+          type: string
+        description: comma separated domain names e.g-> domain=domain1.com,domain2.com
+      - in: query
+        name: port
+        schema:
+          type: string
+        description: comma separated ports e.g. ports=80,443
+      - schema:
+          type: string
+        in: query
+        name: templates
+        description: comma separated templates e.g. templates=tech-detect,azure-takeover
+      - schema:
+          type: string
+        in: query
+        name: time
+        description: filter by time ( last_day, last_week, last_month )
+      - schema:
+          type: string
+        in: query
+        name: vuln_status
+        description: comma separated vuln_status e.g vuln_status=open,fixed
+      - schema:
+          type: string
+        in: query
+        name: tags
+        description: comma separated tags e.g tags=xss,cve
+      - schema:
+          type: string
+        in: query
+        name: sort_asc
+        description: comma separated ascending sorting e.g sort_asc=created_at,severity
+      - schema:
+          type: string
+        in: query
+        name: sort_desc
+        description: comma separated descending sorting e.g sort_desc=created_at,severity
+      - schema:
+          type: boolean
+        in: query
+        name: is_ticket
+        description: Return the records that have issue trackers
+      - in: query
+        name: labels
+        schema:
+          type: string
+        description: filter by comma separated labels e.g labels=p1,p2
+      - in: query
+        name: category
+        schema:
+          type: string
+        description: filter by comma separated categories e.g category=cve,xss
+      - in: query
+        name: is_regression
+        schema:
+          type: boolean
+        description: filter by is_regression
+      - schema:
+          type: boolean
+        in: query
+        name: asset_metadata
+        description: Asset details for the vulnerability
+      - schema:
+          type: string
+        in: header
+        name: X-Team-Id
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+      security:
+      - X-API-Key: []
+    parameters: []
+  /v1/scans/stats:
+    get:
+      summary: Get All Scan Stats
+      tags:
+      - scans
+      responses:
+        '200':
+          $ref: '#/components/responses/ScanStatsResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '403':
+          $ref: '#/components/responses/ErrorResponse'
+        '499':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v1-scans-stats
+      parameters:
+      - schema:
+          type: string
+        in: header
+        name: X-Team-Id
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+      security:
+      - X-API-Key: []
+      description: Get all scans statistics for a user
   /v1/scans/{vuln_id}/retest:
     parameters:
     - schema:
@@ -645,6 +1008,280 @@ paths:
               properties:
                 socks5_proxy:
                   type: string
+  /v1/scans/results/filters:
+    get:
+      summary: Get Scans Result Filters
+      tags:
+      - results
+      responses:
+        '200':
+          $ref: '#/components/responses/GetScanResultsFiltersResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '499':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v1-scans-results-filters
+      description: Get users scan-result filters
+      security:
+      - X-API-Key: []
+      parameters:
+      - schema:
+          type: integer
+        in: query
+        name: offset
+        description: The number of items to skip before starting to collect the result set
+      - schema:
+          type: integer
+        in: query
+        name: limit
+        description: The numbers of items to return
+      - schema:
+          type: string
+        in: query
+        name: scan_id
+        description: specific scan_id results filters
+      - schema:
+          type: string
+        in: query
+        name: severity
+        description: comma separated severity e.g. severities=info,high
+      - schema:
+          type: string
+        in: query
+        name: templates
+        description: comma separated templates e.g. templates=tech-detect,azure-takeover
+      - schema:
+          type: string
+        in: query
+        name: host
+        description: comma separated host e.g. hosts=https://example.com,https://x.com
+      - in: query
+        name: domain
+        schema:
+          type: string
+        description: comma separated domain names e.g-> domain=domain1.com,domain2.com
+      - in: query
+        name: port
+        schema:
+          type: string
+        description: comma separated ports e.g. ports=80,443
+      - schema:
+          type: string
+        in: query
+        name: search
+        description: search term
+      - schema:
+          type: string
+        in: query
+        name: type
+        required: true
+        description: type of filter
+      - schema:
+          type: string
+        in: query
+        name: time
+        description: filter by time ( last_day, last_week, last_month )
+      - schema:
+          type: string
+        in: query
+        name: vuln_status
+        description: comma separated vuln_status e.g vuln_status=open,fixed
+      - schema:
+          type: string
+        in: query
+        name: sort_asc
+        description: comma separated ascending sorting e.g sort_asc=created_at,severity
+      - schema:
+          type: string
+        in: query
+        name: sort_desc
+        description: comma separated descending sorting e.g sort_desc=created_at,severity
+      - schema:
+          type: string
+        in: query
+        name: tags
+        description: comma separated tags e.g tags=xss,cve
+      - schema:
+          type: string
+        in: query
+        name: not_hosts
+        description: comma separated hosts that should not be returned e.g. not_hosts=https://example.com,https://x.com
+      - schema:
+          type: string
+        in: query
+        name: not_severity
+        description: comma separated severity that should not be returned e.g. not_severity=info,high
+      - schema:
+          type: string
+        in: query
+        name: not_templates
+        description: comma separated templates that should not be returned e.g. not_templates=tech-detect,azure-takeover
+      - in: query
+        name: labels
+        schema:
+          type: string
+        description: filter by comma separated labels e.g labels=p1,p2
+      - in: query
+        name: category
+        schema:
+          type: string
+        description: filter by comma separated categories e.g category=cve,xss
+      - in: query
+        name: is_regression
+        schema:
+          type: boolean
+        description: filter by is_regression
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+      - schema:
+          type: string
+          format: date
+        in: query
+        name: start_date
+        description: time filter start date
+      - schema:
+          type: string
+          format: date
+        in: query
+        name: end_date
+        description: time filter end date
+  /v1/scans/results/stats:
+    get:
+      summary: Get Results Stats
+      tags:
+      - results
+      responses:
+        '200':
+          $ref: '#/components/responses/GetScanResultStatsResponse'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '499':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v1-scans-results-stats
+      description: Get user scan results stats
+      security:
+      - X-API-Key: []
+      parameters:
+      - schema:
+          type: integer
+        in: query
+        name: offset
+        description: The number of items to skip before starting to collect the result set
+      - schema:
+          type: integer
+        in: query
+        name: limit
+        description: The numbers of items to return
+      - schema:
+          type: string
+        in: query
+        name: host
+        description: comma separated host e.g. hosts=https://example.com,https://x.com
+      - in: query
+        name: domain
+        schema:
+          type: string
+        description: comma separated domain names e.g-> domain=domain1.com,domain2.com
+      - in: query
+        name: port
+        schema:
+          type: string
+        description: comma separated ports e.g. ports=80,443
+      - schema:
+          type: string
+        in: query
+        name: templates
+        description: comma separated templates e.g. templates=tech-detect,azure-takeover
+      - schema:
+          type: string
+        in: query
+        name: severity
+        description: comma separated severity e.g. severities=info,high
+      - schema:
+          type: string
+        in: query
+        name: search
+        description: search term
+      - schema:
+          type: string
+        in: query
+        name: scan_id
+        description: specific scan_id results filters
+      - schema:
+          type: string
+        in: query
+        description: filter by time ( last_day, last_week, last_month )
+        name: time
+      - schema:
+          type: string
+        in: query
+        name: vuln_status
+        description: comma separated vuln_status e.g vuln_status=open,fixed
+      - schema:
+          type: string
+        in: query
+        name: tags
+        description: comma separated tags e.g tags=xss,cve
+      - schema:
+          type: string
+        in: query
+        name: not_hosts
+        description: comma separated hosts that should not be returned e.g. not_hosts=https://example.com,https://x.com
+      - schema:
+          type: string
+        in: query
+        name: not_severity
+        description: comma separated severity that should not be returned e.g. not_severity=info,high
+      - schema:
+          type: string
+        in: query
+        name: not_templates
+        description: comma separated templates that should not be returned e.g. not_templates=tech-detect,azure-takeover
+      - in: query
+        name: labels
+        schema:
+          type: string
+        description: filter by comma separated labels e.g labels=p1,p2
+      - in: query
+        name: category
+        schema:
+          type: string
+        description: filter by comma separated categories e.g category=cve,xss
+      - in: query
+        name: is_regression
+        schema:
+          type: boolean
+        description: filter by is_regression
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+      - schema:
+          type: string
+          format: date
+        in: query
+        name: start_date
+        description: time filter start date
+      - schema:
+          type: string
+          format: date
+        in: query
+        name: end_date
+        description: time filter end date
   /v1/scans/schedule:
     get:
       summary: Get Scan Schedules
@@ -729,6 +1366,70 @@ paths:
       security:
       - X-API-Key: []
       description: Delete scan schedule for a user
+  /v1/retest:
+    get:
+      summary: Get All Retest
+      tags:
+      - retests
+      responses:
+        '200':
+          $ref: '#/components/responses/GetRetestResultsResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v1-retest
+      description: Get user retest results
+      security:
+      - X-API-Key: []
+      parameters:
+      - schema:
+          type: integer
+        in: query
+        name: offset
+        description: number of results to skip
+        required: true
+      - schema:
+          type: integer
+        in: query
+        name: limit
+        description: number of results
+        required: true
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+    post:
+      summary: Create Retest
+      tags:
+      - retests
+      operationId: post-v1-retest
+      responses:
+        '200':
+          $ref: '#/components/responses/PostRetestTemplateResponse'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      description: Trigger a retest scan
+      security:
+      - X-API-Key: []
+      requestBody:
+        $ref: '#/components/requestBodies/RetestTemplateRequest'
+      parameters:
+      - schema:
+          type: string
+        in: header
+        name: X-Team-Id
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+    parameters: []
   /v1/retest/{vuln_id}:
     get:
       summary: Get Retest Vulnerability
@@ -761,6 +1462,482 @@ paths:
       name: vuln_id
       in: path
       required: true
+  /v1/assets:
+    get:
+      summary: Get Asset List
+      tags:
+      - assets
+      responses:
+        '200':
+          $ref: '#/components/responses/GetAssetsListResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v1-assets
+      description: Get user asset list
+      security:
+      - X-API-Key: []
+      parameters:
+      - schema:
+          type: integer
+        in: query
+        name: offset
+        description: number of assets to skip
+      - schema:
+          type: integer
+        in: query
+        name: limit
+        description: number of assets to fetch
+      - schema:
+          type: string
+        in: query
+        name: search
+        description: search term for asset list
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+    post:
+      summary: Upload Asset
+      tags:
+      - assets
+      operationId: post-v1-assets
+      responses:
+        '200':
+          $ref: '#/components/responses/UploadAssetResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      security:
+      - X-API-Key: []
+      requestBody:
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+      parameters:
+      - schema:
+          type: string
+        in: query
+        name: name
+        description: name of asset
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+      - schema:
+          type: string
+        in: header
+        description: set the content type header
+        name: Content-Type
+      description: Manually upload user assets (uploaded to manual enumeration)
+  /v1/assets/{asset_Id}:
+    parameters:
+    - schema:
+        type: string
+      name: asset_Id
+      in: path
+      required: true
+    get:
+      summary: Get Asset Metadata
+      tags:
+      - assets
+      responses:
+        '200':
+          $ref: '#/components/responses/GetUserAssetResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v1-assets-assetId
+      security:
+      - X-API-Key: []
+      description: Get asset metadata
+      parameters:
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+    delete:
+      summary: Delete Asset
+      tags:
+      - assets
+      operationId: delete-v1-assets-asset_Id
+      responses:
+        '200':
+          $ref: '#/components/responses/DeleteAssetResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      security:
+      - X-API-Key: []
+      description: Delete asset by ID
+      parameters:
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+    patch:
+      summary: Update Asset Metadata
+      tags:
+      - assets
+      operationId: patch-v1-assets-asset_Id
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                - message
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      security:
+      - X-API-Key: []
+      requestBody:
+        $ref: '#/components/requestBodies/UpdateAssetRequest'
+      description: Update asset metadata
+      parameters:
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+  /v1/assets/{asset_id}/contents:
+    get:
+      summary: Get Asset Content
+      tags:
+      - assets
+      responses:
+        '200':
+          description: OK
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v1-assets-id-contents
+      security:
+      - X-API-Key: []
+      description: Get user asset content
+      parameters:
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+    parameters:
+    - schema:
+        type: string
+      name: asset_id
+      in: path
+      required: true
+    patch:
+      summary: Update Asset Content
+      tags:
+      - assets
+      operationId: patch-v1-assets-asset_id-contents
+      responses:
+        '200':
+          $ref: '#/components/responses/PatchAssetContentResponse'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      requestBody:
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+      security:
+      - X-API-Key: []
+      parameters:
+      - schema:
+          type: string
+          enum:
+          - append
+          - replace
+        in: query
+        name: update_type
+        description: 'use append or replace '
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+      - schema:
+          type: string
+        in: header
+        description: set the content type header
+        name: Content-Type
+      description: Update existing asset content
+  /v1/user/notification_preference:
+    get:
+      summary: Get User Notification Preferences
+      operationId: get-v1-user-notification-preference
+      tags:
+      - user
+      responses:
+        '200':
+          description: User notification preferences
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                - weekly_digest_email
+                - onboard_preference
+                - real_time_autoscan
+                - enable_auto_retest
+                properties:
+                  weekly_digest_email:
+                    type: boolean
+                    description: Whether to receive weekly digest emails
+                  onboard_preference:
+                    type: object
+                    additionalProperties: true
+                    description: Dynamic key-value pairs for onboarding preferences
+                  real_time_autoscan:
+                    type: boolean
+                    description: Whether to receive real-time autoscan notifications
+                  enable_auto_retest:
+                    type: boolean
+                    description: Whether to enable auto retest
+                  leaks_notifications:
+                    type: object
+                    description: Leak notification preferences by type
+                    properties:
+                      my_leaks:
+                        type: boolean
+                        description: Personal email leak notifications
+                      employee_leaks:
+                        type: boolean
+                        description: Corporate/employee domain leak notifications
+                      customer_leaks:
+                        type: boolean
+                        description: Customer domain leak notifications
+        '401':
+          $ref: '#/components/responses/MessageResponse'
+        '500':
+          $ref: '#/components/responses/MessageResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      security:
+      - X-API-Key: []
+      description: Get user's notification preferences
+    patch:
+      summary: Update User Notification Preferences
+      operationId: patch-v1-user-notification-preference
+      tags:
+      - user
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                weekly_digest_email:
+                  type: boolean
+                  description: Whether to receive weekly digest emails
+                onboard_preference:
+                  type: object
+                  additionalProperties: true
+                  description: Dynamic key-value pairs for onboarding preferences
+                leaks_notifications:
+                  type: object
+                  description: Leak notification preferences by type
+                  properties:
+                    my_leaks:
+                      type: boolean
+                      description: Personal email leak notifications
+                    employee_leaks:
+                      type: boolean
+                      description: Corporate/employee domain leak notifications
+                    customer_leaks:
+                      type: boolean
+                      description: Customer domain leak notifications
+                real_time_autoscan:
+                  type: boolean
+                  description: Whether to receive real-time autoscan notifications
+                enable_auto_retest:
+                  type: boolean
+                  description: Whether to enable auto retest
+      responses:
+        '200':
+          description: Successfully updated notification preferences
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Notification preferences updated successfully
+        '400':
+          $ref: '#/components/responses/MessageResponse'
+        '401':
+          $ref: '#/components/responses/MessageResponse'
+        '500':
+          $ref: '#/components/responses/MessageResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      security:
+      - X-API-Key: []
+      description: Update user's notification preferences
+  /v1/user/feedback:
+    post:
+      summary: Create Feedback
+      tags:
+      - users
+      operationId: post-v1-user-feedback
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                - message
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      security:
+      - X-API-Key: []
+      requestBody:
+        $ref: '#/components/requestBodies/PostFeedbackRequest'
+      description: Add user feedback
+      parameters:
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+  /v1/user/delete/code:
+    parameters: []
+    post:
+      summary: Email user deletion verification code
+      tags:
+      - users
+      responses:
+        '200':
+          $ref: '#/components/responses/MessageResponse'
+        '400':
+          $ref: '#/components/responses/MessageResponse'
+        '403':
+          $ref: '#/components/responses/MessageResponse'
+        '500':
+          $ref: '#/components/responses/MessageResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: post-v1-user-delete-code
+      security:
+      - X-API-Key: []
+      description: generate and email user deletion verification code
+      parameters:
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+  /v1/user:
+    get:
+      summary: Get User Profile
+      tags:
+      - users
+      responses:
+        '200':
+          $ref: '#/components/responses/GetUserProfileResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v1-user
+      security:
+      - X-API-Key: []
+      description: Get user profile and permissions
+      parameters:
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+    delete:
+      summary: Delete user from system along with all data
+      tags:
+      - users
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                code:
+                  type: string
+              required:
+              - code
+      responses:
+        '200':
+          $ref: '#/components/responses/MessageResponse'
+        '400':
+          $ref: '#/components/responses/MessageResponse'
+        '403':
+          $ref: '#/components/responses/MessageResponse'
+        '500':
+          $ref: '#/components/responses/MessageResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: delete-v1-user
+      security:
+      - X-API-Key: []
+      parameters:
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
   /v1/user/apikey:
     get:
       summary: Get API Key
@@ -803,8 +1980,7 @@ paths:
           $ref: '#/components/responses/ErrorResponse'
       security:
       - X-API-Key: []
-      description: Create user api-key, this won't create a new api-key if it already
-        exists.
+      description: Create user api-key, this won't create a new api-key if it already exists.
     delete:
       summary: Delete API Key
       tags:
@@ -826,6 +2002,64 @@ paths:
       security:
       - X-API-Key: []
       description: Delete user api-key
+  /v1/user/promo_code:
+    get:
+      summary: Get Promocode Details
+      tags:
+      - users
+      operationId: get-v1-user-promocode
+      responses:
+        '200':
+          $ref: '#/components/responses/GetPromocodeDetailsResponse'
+        '400':
+          $ref: '#/components/responses/MessageResponse'
+        '401':
+          $ref: '#/components/responses/MessageResponse'
+        '500':
+          $ref: '#/components/responses/MessageResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      security:
+      - X-API-Key: []
+      parameters:
+      - schema:
+          type: string
+        in: query
+        required: true
+        name: promo_code
+        description: Promocode to get details for
+      description: Get promocode details
+    post:
+      summary: Apply Promocode
+      tags:
+      - users
+      responses:
+        '200':
+          $ref: '#/components/responses/MessageResponse'
+        '400':
+          $ref: '#/components/responses/MessageResponse'
+        '401':
+          $ref: '#/components/responses/MessageResponse'
+        '404':
+          $ref: '#/components/responses/MessageResponse'
+        '500':
+          $ref: '#/components/responses/MessageResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: post-v1-user-promocode
+      security:
+      - X-API-Key: []
+      description: Apply promocode
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                promo_code:
+                  type: string
+              required:
+              - promo_code
   /v1/user/apikey/rotate:
     post:
       summary: Rotate API Key
@@ -848,6 +2082,211 @@ paths:
       security:
       - X-API-Key: []
       description: Rotate user api-key
+  /v1/user/domain-verification/request:
+    post:
+      summary: Request Domain Verification
+      tags:
+      - users
+      operationId: post-v1-user-domain-verification-request
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  domain:
+                    type: string
+                    description: The domain to be verified
+                  verification_string:
+                    type: string
+                    description: The TXT record value to add to DNS
+                required:
+                - domain
+                - verification_string
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '429':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      security:
+      - X-API-Key: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                domain:
+                  type: string
+                  description: Root domain to verify (e.g., example.com)
+                  example: example.com
+              required:
+              - domain
+      description: Request domain ownership verification through DNS TXT record. Only root domains are supported.
+      parameters:
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+    delete:
+      summary: Request Domain Delete
+      tags: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                - domain
+                - message
+                properties:
+                  domain:
+                    type: string
+                    description: The domain to be deleted
+                  message:
+                    type: string
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '429':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: delete-v1-user-domain-verification-request
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - domain
+              properties:
+                domain:
+                  type: string
+                  description: Root domain to delete (e.g., example.com)
+      description: Delete domain verification request. Only root domains are supported.
+      security:
+      - X-API-Key: []
+      parameters:
+      - schema:
+          type: string
+        in: header
+        name: X-Team-Id
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+  /v1/user/domain-verification/confirm:
+    post:
+      summary: Confirm Domain Verification
+      tags:
+      - users
+      operationId: post-v1-user-domain-verification-confirm
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    description: Success message
+                  domain:
+                    type: string
+                    description: The verified domain
+                required:
+                - message
+                - domain
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    description: Error message
+                required:
+                - message
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      security:
+      - X-API-Key: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                domain:
+                  type: string
+                  description: Root domain to confirm verification for
+                  example: example.com
+              required:
+              - domain
+      description: Confirm domain ownership by checking if the required DNS TXT record has been added.
+      parameters:
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+  /v1/user/domain-verification/status:
+    get:
+      summary: Get Domain Verification Status
+      tags:
+      - users
+      operationId: get-v1-user-domain-verification-status
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  verification_requests:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/DomainVerificationRequest'
+                required:
+                - verification_requests
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      security:
+      - X-API-Key: []
+      description: Get the status of all domain verification requests for the authenticated user, including pending, verified, and expired requests.
+      parameters:
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
   /v1/template/public:
     get:
       summary: Get Public Template List
@@ -1379,119 +2818,42 @@ paths:
         default:
           $ref: '#/components/responses/ErrorResponse'
       operationId: delete-v1-template-share-template_id
-  /v1/user/team/member:
-    get:
-      summary: Get Team Members
-      tags:
-      - internal
-      responses:
-        '200':
-          $ref: '#/components/responses/GetTeamMembersResponse'
-        '401':
-          $ref: '#/components/responses/ErrorResponse'
-        '403':
-          $ref: '#/components/responses/ErrorResponse'
-        '500':
-          $ref: '#/components/responses/ErrorResponse'
-        default:
-          $ref: '#/components/responses/ErrorResponse'
-      operationId: get-v1-user-team-member
-      security:
-      - X-API-Key: []
-      description: Get team member list
-      parameters:
-      - schema:
-          type: string
-        in: header
-        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
-        name: X-Team-Id
+  /v1/admin/user/delete:
+    parameters: []
+  /v1/user/migrate_to_team:
     post:
-      summary: Add Team Member
-      operationId: post-v1-user-team-member
+      summary: Migrate Personal workspace data to a new team
       tags:
-      - internal
+      - user
       responses:
         '200':
-          $ref: '#/components/responses/MessageResponse'
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  team_id:
+                    type: string
+                required:
+                - message
+                - team_id
         '400':
           $ref: '#/components/responses/MessageResponse'
         '401':
-          $ref: '#/components/responses/MessageResponse'
-        '403':
           $ref: '#/components/responses/MessageResponse'
         '500':
           $ref: '#/components/responses/MessageResponse'
         default:
           $ref: '#/components/responses/ErrorResponse'
+      operationId: post-v1-user-migrate-to-team
+      requestBody:
+        $ref: '#/components/requestBodies/CreateTeamRequest'
       security:
       - X-API-Key: []
-      requestBody:
-        $ref: '#/components/requestBodies/AddTeamMemberRequest'
-      description: Invite a new team member
-      parameters:
-      - schema:
-          type: string
-        in: header
-        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
-        name: X-Team-Id
-    delete:
-      summary: Delete Team Member
-      operationId: delete-v1-user-team-member
-      tags:
-      - internal
-      responses:
-        '200':
-          $ref: '#/components/responses/MessageResponse'
-        '400':
-          $ref: '#/components/responses/MessageResponse'
-        '401':
-          $ref: '#/components/responses/MessageResponse'
-        '403':
-          $ref: '#/components/responses/MessageResponse'
-        '500':
-          $ref: '#/components/responses/MessageResponse'
-        default:
-          $ref: '#/components/responses/ErrorResponse'
-      security:
-      - X-API-Key: []
-      requestBody:
-        $ref: '#/components/requestBodies/DeleteTeamMemberRequest'
-      description: Delete a team member using member email
-      parameters:
-      - schema:
-          type: string
-        in: header
-        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
-        name: X-Team-Id
-    patch:
-      summary: Update Team Member
-      operationId: patch-v1-user-team-member
-      tags:
-      - internal
-      responses:
-        '200':
-          $ref: '#/components/responses/MessageResponse'
-        '400':
-          $ref: '#/components/responses/MessageResponse'
-        '401':
-          $ref: '#/components/responses/MessageResponse'
-        '403':
-          $ref: '#/components/responses/MessageResponse'
-        '500':
-          $ref: '#/components/responses/MessageResponse'
-        default:
-          $ref: '#/components/responses/ErrorResponse'
-      security:
-      - X-API-Key: []
-      requestBody:
-        $ref: '#/components/requestBodies/PatchTeamMemberRequest'
-      description: Accept team invite
-      parameters:
-      - schema:
-          type: string
-        in: header
-        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
-        name: X-Team-Id
+      description: Migrate Personal workspace data to a new team
   /v1/scans/scan_ips:
     get:
       summary: Get Scan IPs
@@ -1799,9 +3161,76 @@ paths:
                   type: array
                   items:
                     type: string
+                time:
+                  $ref: '#/components/schemas/TimeRangeQueryParameter'
+                start_date:
+                  type: string
+                  format: date
+                end_date:
+                  type: string
+                  format: date
       security:
       - X-API-Key: []
       description: Export filtered scan results
+  /v1/export/list:
+    get:
+      summary: Get export list for user
+      tags:
+      - export
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                - current_page
+                - result_count
+                - total_results
+                - total_pages
+                - data
+                properties:
+                  current_page:
+                    type: integer
+                  result_count:
+                    type: integer
+                  total_results:
+                    type: integer
+                  total_pages:
+                    type: integer
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ExportListItem'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '403':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v1-export-list
+      parameters:
+      - schema:
+          type: integer
+        in: query
+        name: offset
+        description: The number of items to skip before starting to collect the result set
+      - schema:
+          type: integer
+        in: query
+        name: limit
+      - schema:
+          type: string
+        in: query
+        name: export_status
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
   /v1/scans/vuln/{vuln_id}/export:
     parameters:
     - schema:
@@ -1982,8 +3411,7 @@ paths:
       - schema:
           type: integer
         in: query
-        description: The number of items to skip before starting to collect the result
-          set
+        description: The number of items to skip before starting to collect the result set
         name: offset
       - schema:
           type: string
@@ -2151,6 +3579,72 @@ paths:
         in: header
         description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
         name: X-Team-Id
+  /v1/scans/config/verify:
+    post:
+      summary: Verify Config
+      tags:
+      - configurations
+      responses:
+        '200':
+          $ref: '#/components/responses/VerifyConfigResponse'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: post-v1-scans-config-verify
+      requestBody:
+        $ref: '#/components/requestBodies/VerifyConfigRequest'
+      security:
+      - X-API-Key: []
+      description: Verify scan configuration
+      parameters:
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+  /v1/scans/config/verify/contents:
+    post:
+      summary: Get Verify Config Contents
+      tags:
+      - configurations
+      responses:
+        '200':
+          $ref: '#/components/responses/VerifyConfigContentsResponse'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: post-v1-scans-config-verify-contents
+      requestBody:
+        $ref: '#/components/requestBodies/VerifyConfigContentsRequest'
+      security:
+      - X-API-Key: []
+      description: Get Verify scan configuration contents
+      parameters:
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+      - schema:
+          type: string
+        in: query
+        description: Jira Project ID to fetch details for
+        name: project_id
+      - schema:
+          type: string
+        in: query
+        description: Linear Team ID to fetch details for
+        name: team_id
   /v1/scans/{scan_id}/config:
     parameters:
     - schema:
@@ -2234,6 +3728,142 @@ paths:
         in: header
         description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
         name: X-Team-Id
+  /v1/payment/stripe/invoices:
+    get:
+      summary: Get a list of invoices for a customer
+      operationId: get-v1-payment-stripe-invoices
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/InvoiceItem'
+                required:
+                - data
+        '400':
+          $ref: '#/components/responses/MessageResponse'
+        '401':
+          $ref: '#/components/responses/MessageResponse'
+        '500':
+          $ref: '#/components/responses/MessageResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      security:
+      - X-API-Key: []
+  /v1/payment/stripe/checkout_session:
+    parameters: []
+  /v1/user/subscription:
+    get:
+      summary: Get Subscription Status
+      tags:
+      - users
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                  message:
+                    type: string
+                  amount:
+                    type: integer
+                  monthly_token:
+                    type: integer
+                  price_id:
+                    type: string
+                  recurrence:
+                    type: string
+                  from:
+                    type: string
+                  to:
+                    type: string
+                  card:
+                    type: string
+                  brand:
+                    type: string
+                  payment_mode:
+                    type: string
+                  cancel_at:
+                    type: string
+                  trial:
+                    type: string
+                required:
+                - status
+                - message
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v1-user-subscription
+      security:
+      - X-API-Key: []
+      description: Get user subscription status
+      parameters:
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+    patch:
+      summary: Update current subscription
+      tags:
+      - users
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                - message
+                - status
+                properties:
+                  message:
+                    type: string
+                  invoice:
+                    type: string
+                  status:
+                    type: string
+        '400':
+          $ref: '#/components/responses/MessageResponse'
+        '403':
+          $ref: '#/components/responses/MessageResponse'
+        '500':
+          $ref: '#/components/responses/MessageResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: patch-v1-user-subscription
+      security:
+      - X-API-Key: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - price_id
+              properties:
+                price_id:
+                  type: string
+      parameters:
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
   /v1/asset/enumerate:
     get:
       summary: Get Enumeration List
@@ -2258,8 +3888,7 @@ paths:
           type: integer
         in: query
         name: offset
-        description: The number of items to skip before starting to collect the result
-          set
+        description: The number of items to skip before starting to collect the result set
       - schema:
           type: integer
         in: query
@@ -2426,6 +4055,10 @@ paths:
                   type: boolean
                 per_domain_enumeration:
                   type: boolean
+                exclusions:
+                  type: array
+                  items:
+                    type: string
       security:
       - X-API-Key: []
       description: Create a new enumeration
@@ -2562,6 +4195,358 @@ paths:
       security:
       - X-API-Key: []
       description: Delete enumeration by enumerate_id
+      parameters:
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+  /v1/asset/enumerate/{enumerate_id}/contents:
+    parameters:
+    - schema:
+        type: string
+      name: enumerate_id
+      in: path
+      required: true
+    get:
+      summary: Get Enumeration Contents
+      tags:
+      - enumerations
+      responses:
+        '200':
+          $ref: '#/components/responses/GetEnumerateIdContents'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '403':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v1-asset-enumerate-enumerate_id-contents
+      parameters:
+      - schema:
+          type: integer
+          default: 0
+        in: query
+        name: offset
+        description: The number of items to skip before starting to collect the result set
+      - schema:
+          type: integer
+          default: 100
+        in: query
+        name: limit
+        description: The numbers of items to return
+      - schema:
+          type: boolean
+        in: query
+        name: is_tech
+        description: Return records that have technologies
+      - schema:
+          type: boolean
+        in: query
+        name: is_favicon
+        description: Return the records that have favicon
+      - schema:
+          type: string
+        name: search
+        in: query
+        description: Search on the content name
+      - schema:
+          type: string
+        in: query
+        name: labels
+        description: Filter by comma separated labels, e.g-> labels=p1,p2
+      - schema:
+          type: boolean
+        in: query
+        name: is_new
+        description: Filter by new content
+      - schema:
+          type: string
+        in: query
+        name: host
+        description: Filter by comma separated hosts, e.g-> host=p1,p2
+      - schema:
+          type: string
+        in: query
+        name: port
+        description: Filter by comma separated ports, e.g-> port=p1,p2
+      - schema:
+          type: string
+        in: query
+        name: status_code
+        description: Filter by comma separated status codes, e.g-> status_code=p1,p2
+      - schema:
+          type: string
+        in: query
+        name: title
+        description: Filter by comma separated titles, e.g-> title=p1,p2
+      - schema:
+          type: string
+        in: query
+        name: content_length
+        description: Filter by comma separated content lengths, e.g-> content_length=p1,p2
+      - schema:
+          type: string
+        in: query
+        name: cname
+        description: cname to filter
+      - schema:
+          type: string
+        in: query
+        name: domain
+        description: Filter by comma separated domain names, e.g-> domain=domain1.com,domain2.com
+      - schema:
+          type: string
+        in: query
+        name: technologies
+        description: technologies to filter
+      - schema:
+          type: string
+        in: query
+        name: ip
+        description: ips to filter
+      - schema:
+          type: string
+        in: query
+        name: sort_asc
+        description: comma separated ascending sorting e.g sort_asc=created_at,name
+      - schema:
+          type: string
+        in: query
+        name: sort_desc
+        description: comma separated descending sorting e.g sort_desc=created_at,name
+      - schema:
+          type: boolean
+        in: query
+        name: is_screenshot
+        description: asset with screenshots
+      - schema:
+          $ref: '#/components/schemas/TimeRangeQueryParameter'
+          default: all_time
+        in: query
+        name: time
+        description: time filter to select
+      - schema:
+          type: string
+          format: date
+        in: query
+        name: start_date
+        description: time filter start date
+      - schema:
+          type: string
+          format: date
+        in: query
+        name: end_date
+        description: time filter end date
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+      - schema:
+          type: string
+        in: query
+        name: custom_filter
+        description: custom query to filter. double encode the query string.
+      - schema:
+          type: string
+        in: query
+        name: favicon
+        description: Filter by comma separated favicons, e.g-> favicon=p1,p2
+      - schema:
+          type: boolean
+        in: query
+        name: only_dns
+        description: Query only dns FQDN records
+      - schema:
+          type: boolean
+        in: query
+        name: only_ip
+        description: Query only dns IP records
+      security:
+      - X-API-Key: []
+      description: Get enumeration content by enumerate_id
+  /v1/asset/enumerate/contents:
+    get:
+      summary: Get All Enumeration Contents
+      tags:
+      - enumerations
+      responses:
+        '200':
+          $ref: '#/components/responses/GetEnumerateIdContents'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '403':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v1-asset-enumerate-contents
+      parameters:
+      - schema:
+          type: integer
+          default: 0
+        in: query
+        name: offset
+        description: The number of items to skip before starting to collect the result set
+      - schema:
+          $ref: '#/components/schemas/TimeRangeQueryParameter'
+          default: all_time
+        in: query
+        name: time
+        description: time filter to select
+      - schema:
+          type: integer
+          default: 100
+        in: query
+        name: limit
+        description: The numbers of items to return
+      - schema:
+          type: boolean
+        in: query
+        name: is_tech
+        description: Return records that have technologies
+      - schema:
+          type: boolean
+        in: query
+        name: is_favicon
+        description: Return the records that have favicon
+      - schema:
+          type: string
+        name: search
+        in: query
+        description: Search on the content name
+      - schema:
+          type: string
+        in: query
+        name: labels
+        description: Filter by comma separated labels, e.g-> labels=p1,p2
+      - schema:
+          type: boolean
+        in: query
+        name: is_new
+        description: Filter by new content
+      - schema:
+          type: string
+        in: query
+        name: host
+        description: Filter by comma separated labels, e.g-> host=p1,p2
+      - schema:
+          type: string
+        in: query
+        name: port
+        description: Filter by port separated labels, e.g-> port=p1,p2
+      - schema:
+          type: string
+        in: query
+        name: status_code
+        description: Filter by status code separated labels, e.g-> status_code=p1,p2
+      - schema:
+          type: string
+        in: query
+        name: title
+        description: Filter by title separated labels, e.g-> title=p1,p2
+      - schema:
+          type: string
+        in: query
+        name: content_length
+        description: Filter by content length separated labels, e.g-> content_length=p1,p2
+      - schema:
+          type: string
+        in: query
+        name: domain
+        description: Filter by domain names separated labels, e.g-> domain=domain1.com,domain2.com
+      - schema:
+          type: string
+        in: query
+        name: cname
+        description: cname to filter
+      - schema:
+          type: string
+        in: query
+        name: technologies
+        description: technologies to filter
+      - schema:
+          type: string
+        in: query
+        name: ip
+        description: ips to filter
+      - schema:
+          type: string
+        in: query
+        name: sort_asc
+        description: comma separated ascending sorting e.g sort_asc=created_at,name
+      - schema:
+          type: string
+        in: query
+        name: sort_desc
+        description: comma separated descending sorting e.g sort_desc=created_at,name
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+      - schema:
+          type: string
+        in: query
+        name: custom_filter
+        description: custom query to filter. double encode the query string.
+      - schema:
+          type: boolean
+        in: query
+        name: is_screenshot
+        description: asset with screenshots
+      - schema:
+          type: string
+        in: query
+        name: favicon
+        description: Filter by comma separated favicons, e.g-> favicon=p1,p2
+      - schema:
+          type: boolean
+        in: query
+        name: only_dns
+        description: Query only dns FQDN records
+      - schema:
+          type: boolean
+        in: query
+        name: only_ip
+        description: Query only dns IP records
+      security:
+      - X-API-Key: []
+      description: Get All enumeration content
+  /v1/asset/enumerate/{enumerate_id}/stop:
+    parameters:
+    - schema:
+        type: string
+      name: enumerate_id
+      in: path
+      required: true
+    post:
+      summary: Stop Enumeration
+      tags:
+      - enumerations
+      responses:
+        '200':
+          $ref: '#/components/responses/MessageResponse'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: post-v1-asset-enumerate-enumerate_id-stop
+      security:
+      - X-API-Key: []
+      description: Stop a running enumeration
       parameters:
       - schema:
           type: string
@@ -2820,6 +4805,78 @@ paths:
       security:
       - X-API-Key: []
       description: Create an asset group from existing enumeration data using filters
+  /v1/asset/enumerate/group/{group_id}:
+    parameters:
+    - schema:
+        type: string
+      name: group_id
+      in: path
+      required: true
+    delete:
+      summary: Delete an asset group
+      tags:
+      - enumerations
+      responses:
+        '200':
+          $ref: '#/components/responses/MessageResponse'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '403':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: delete-v1-asset-enumerate-group
+      parameters:
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+      security:
+      - X-API-Key: []
+      description: Delete an asset group by id
+    patch:
+      summary: Update an asset group
+      tags:
+      - enumerations
+      responses:
+        '200':
+          $ref: '#/components/responses/MessageResponse'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '403':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      requestBody:
+        $ref: '#/components/requestBodies/UpdateAssetGroupRequest'
+      operationId: patch-v1-asset-enumerate-group
+      parameters:
+      - schema:
+          type: string
+          enum:
+          - append
+          - replace
+          default: append
+        in: query
+        name: update_type
+        description: Append vs Replace update_type. Default is append
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+      security:
+      - X-API-Key: []
+      description: Update an asset group by customising the filters
   /v1/enumeration/schedule:
     get:
       summary: Get Enumeration Schedules
@@ -3109,6 +5166,330 @@ paths:
       security:
       - X-API-Key: []
       description: Get scan history detial by scanId
+  /v1/integration/{name}:
+    parameters:
+    - schema:
+        type: string
+      name: name
+      in: path
+      required: true
+  /v1/integration/{name}/all:
+    parameters:
+    - schema:
+        type: string
+      name: name
+      in: path
+      required: true
+  /v1/template/contribute:
+    parameters: []
+  /v1/integration/{name}/profile:
+    parameters:
+    - schema:
+        type: string
+      name: name
+      in: path
+      required: true
+  /v1/template/github:
+    get:
+      summary: Get Github Template List
+      tags:
+      - templates
+      responses:
+        '200':
+          $ref: '#/components/responses/GetUserTemplateListResponse'
+        '401':
+          $ref: '#/components/responses/MessageResponse'
+        '500':
+          $ref: '#/components/responses/MessageResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v1-github-templates
+      security:
+      - X-API-Key: []
+      description: List of all user's github templates
+      parameters:
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+      - schema:
+          type: integer
+        in: query
+        name: offset
+      - schema:
+          type: integer
+        in: query
+        name: limit
+      - schema:
+          type: string
+        in: query
+        name: fields
+    parameters: []
+  /v1/template/github/{id}:
+    parameters:
+    - schema:
+        type: string
+      name: id
+      in: path
+      required: true
+      description: 'unique Id of template '
+    get:
+      summary: Get Github Template
+      tags:
+      - templates
+      responses:
+        '200':
+          $ref: '#/components/responses/GetTemplateResponse'
+        '400':
+          $ref: '#/components/responses/MessageResponse'
+        '401':
+          $ref: '#/components/responses/MessageResponse'
+        '404':
+          $ref: '#/components/responses/MessageResponse'
+        '500':
+          $ref: '#/components/responses/MessageResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      parameters:
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+      operationId: get-v1-github-templates-id
+      requestBody:
+        content: {}
+      description: Get github template text
+      security:
+      - X-API-Key: []
+  /v1/template/stats:
+    get:
+      summary: Get Public Template Stats
+      tags:
+      - templates
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                - message
+                properties:
+                  message:
+                    type: string
+                  facets:
+                    $ref: '#/components/schemas/TemplateStats'
+        '400':
+          $ref: '#/components/responses/MessageResponse'
+        '401':
+          $ref: '#/components/responses/MessageResponse'
+        '500':
+          $ref: '#/components/responses/MessageResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v1-template-stats
+      parameters:
+      - schema:
+          type: integer
+        in: query
+        name: limit
+        description: Limit The numbers of items to return
+      - schema:
+          type: integer
+        in: query
+        name: offset
+        description: Offset The numbers of items to skip
+      - schema:
+          type: string
+        in: query
+        name: fields
+      - schema:
+          type: string
+        in: query
+        name: sort_asc
+        description: SortAsc Sort results in ascending order (CSV field names)
+      - schema:
+          type: string
+        in: query
+        name: sort_desc
+        description: SortDesc Sort results in descending order (CSV field names)
+      - schema:
+          type: string
+        in: query
+        name: q
+      - schema:
+          type: boolean
+        in: query
+        name: highlight
+        description: Highlight Whether to highlight the search results
+      security:
+      - X-API-Key: []
+      description: Get public template statistics
+  /v1/scans/{scan_id}/error_log:
+    parameters:
+    - schema:
+        type: string
+      name: scan_id
+      in: path
+      required: true
+    get:
+      summary: Get elogs of given scan id
+      tags:
+      - elog
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                - logs
+                - next_page_token
+                properties:
+                  logs:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ScanLogResp'
+                  next_page_token:
+                    type: string
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-scans-id-elog
+      parameters:
+      - schema:
+          type: string
+        in: query
+        name: host
+        description: target to search in log
+      - schema:
+          type: string
+        in: query
+        name: template
+        description: template to search in log
+      - schema:
+          type: string
+        in: query
+        name: matched
+        description: status to search in log
+      - schema:
+          type: string
+          format: date-time
+        in: query
+        name: time
+        description: time to filter the logs
+      - schema:
+          type: string
+        in: query
+        name: search
+        description: string to search in error, target and template
+      - schema:
+          type: string
+        in: query
+        name: error
+        description: error to search in log
+      - schema:
+          type: string
+        in: query
+        name: next_page_token
+        description: next page token
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+      - schema:
+          type: string
+        in: query
+        name: template_severity
+        description: severity to search in log
+  /v1/scans/{scan_id}/scan_log:
+    parameters:
+    - schema:
+        type: string
+      name: scan_id
+      in: path
+      required: true
+    get:
+      summary: Get scan log of given scan id
+      tags:
+      - scan_log
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                - logs
+                - next_page_token
+                properties:
+                  logs:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ScanLogResp'
+                  next_page_token:
+                    type: string
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-scans-id-scan-log
+      parameters:
+      - schema:
+          type: string
+        in: query
+        name: host
+        description: target to search in log
+      - schema:
+          type: string
+        in: query
+        name: template
+        description: template to search in log
+      - schema:
+          type: string
+        in: query
+        name: matched
+        description: status to search in log
+      - schema:
+          type: string
+          format: date-time
+        in: query
+        name: time
+        description: time to filter the logs
+      - schema:
+          type: string
+        in: query
+        name: search
+        description: string to search in error, target and template
+      - schema:
+          type: string
+        in: query
+        name: next_page_token
+      - schema:
+          type: string
+        in: query
+        name: template_severity
+        description: severity to search in log
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
   /v1/scans/{scan_id}/scan_log/export:
     parameters:
     - schema:
@@ -3219,6 +5600,103 @@ paths:
           x-go-type-name: ScanLogExportSeverityTypes
         in: query
         name: severity
+  /v1/scans/{scan_id}/scan_log/stats:
+    parameters:
+    - schema:
+        type: string
+      name: scan_id
+      in: path
+      required: true
+    get:
+      summary: Get scan log stats of given scan id
+      tags:
+      - scan_log
+      - stats
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  info_count:
+                    type: integer
+                    format: int64
+                  error_count:
+                    type: integer
+                    format: int64
+                  total_count:
+                    type: integer
+                    format: int64
+                  matched_count:
+                    type: integer
+                    format: int64
+                  unmatched_count:
+                    type: integer
+                    format: int64
+                required:
+                - info_count
+                - error_count
+                - total_count
+                - matched_count
+                - unmatched_count
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-scans-id-scan-log-stats
+      parameters:
+      - schema:
+          type: integer
+          format: int64
+        in: query
+        name: rescan_count
+      - schema:
+          type: string
+        in: query
+        name: host
+        description: target to search in log
+      - schema:
+          type: string
+        in: query
+        name: template
+        description: template to search in log
+      - schema:
+          type: string
+        in: query
+        name: matched
+        description: status to search in log
+      - schema:
+          type: string
+          format: date-time
+        in: query
+        name: time
+        description: time to filter the logs
+      - schema:
+          type: string
+        in: query
+        name: search
+        description: string to search in error, target and template
+      - schema:
+          type: string
+        in: query
+        name: error
+        description: error to search in log
+      - schema:
+          type: string
+          enum:
+          - error
+          - info
+          - all_logs
+          default: all_logs
+          x-go-type: ScanLogExportSeverityTypes
+        in: query
+        name: severity
   /v1/scans/vulns/history:
     get:
       summary: Get scan log stats of given scan id
@@ -3254,6 +5732,92 @@ paths:
         name: history_limit
         required: false
         description: Specifies the maximum number of revisions to be returned.
+  /v1/scans/vulns/{vuln_id}/ticket:
+    parameters:
+    - schema:
+        type: string
+      name: vuln_id
+      in: path
+      required: true
+    post:
+      summary: Create vulns export to tracker
+      tags:
+      - scans
+      responses:
+        '200':
+          $ref: '#/components/responses/VulnsTrackerExportResponse'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '424':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: post-vulns-id-ticket
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                custom_reporting_id:
+                  type: string
+                custom_reporting_url:
+                  type: string
+      parameters:
+      - schema:
+          type: string
+        in: query
+        name: reporting_config_id
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+      security:
+      - X-API-Key: []
+      description: Create vulns export to tracker
+    delete:
+      summary: Delete vulns tracker association
+      tags:
+      - Scans
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '424':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: delete-vulns-id-ticket
+      parameters:
+      - schema:
+          type: string
+        in: query
+        name: provider_name
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+      security:
+      - X-API-Key: []
+      description: Delete vulns export tracker
   /v1/scans/config/exclude:
     get:
       summary: Get excluded templates
@@ -3335,6 +5899,208 @@ paths:
       - X-API-Key: []
       description: Delete excluded templates or targets by ids
     parameters: []
+  /v1/scans/asset:
+    get:
+      summary: Get list of unique assets scanned in current month.
+      tags:
+      - scans
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                - data
+                - workspace_assets
+                - total_assets
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ScanAssetListItem'
+                  workspace_assets:
+                    type: integer
+                  total_assets:
+                    type: integer
+        '400':
+          $ref: '#/components/responses/MessageResponse'
+        '401':
+          $ref: '#/components/responses/MessageResponse'
+        '404':
+          $ref: '#/components/responses/MessageResponse'
+        '500':
+          $ref: '#/components/responses/MessageResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v1-scans-assets
+      security:
+      - X-API-Key: []
+      description: List of all unique assets scanned in the current month.
+      parameters:
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+      - schema:
+          type: string
+        in: query
+        name: search
+        description: Search with host or port
+      - schema:
+          type: integer
+        in: query
+        name: limit
+        description: Limit the number of assets (Default 100)
+      - schema:
+          type: integer
+        in: query
+        name: offset
+        description: Offset the number of assets (Default 0)
+      - schema:
+          type: string
+          format: date
+        in: query
+        name: start_date
+        description: Start date of the range. If not provided, it will be the first day of the current billing cycle.
+      - schema:
+          type: string
+          format: date
+        in: query
+        name: end_date
+        description: End date of the range. If not provided, it will be the last day of the current billing cycle.
+      - schema:
+          type: string
+          enum:
+          - host
+        in: query
+        name: type
+        description: Type of asset to filter by. Supported values are host, if not provided, it will return all assets.
+    parameters: []
+  /v1/scans/asset/export:
+    get:
+      summary: Export list of unique assets scanned in current month
+      tags:
+      - scans
+      responses:
+        '200':
+          description: OK
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+        '400':
+          $ref: '#/components/responses/MessageResponse'
+        '401':
+          $ref: '#/components/responses/MessageResponse'
+        '404':
+          $ref: '#/components/responses/MessageResponse'
+        '500':
+          $ref: '#/components/responses/MessageResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v1-scans-assets-export
+      security:
+      - X-API-Key: []
+      description: Export the list of all unique assets scanned in the current month.
+      parameters:
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+      - schema:
+          type: string
+        in: query
+        name: search
+        description: Search with host or port
+      - schema:
+          type: string
+        in: query
+        name: format
+        description: supported format is csv, json, or raw (default json)
+      - schema:
+          type: string
+          format: date
+        in: query
+        name: start_date
+        description: Start date of the range. If not provided, it will be the first day of the current billing cycle.
+      - schema:
+          type: string
+          format: date
+        in: query
+        name: end_date
+        description: End date of the range. If not provided, it will be the last day of the current billing cycle.
+      - schema:
+          type: string
+          enum:
+          - host
+        in: query
+        name: type
+        description: Type of asset to filter by. Supported values are host, if not provided, it will return all assets.
+    parameters: []
+  /v1/scans/{scan_id}/asset:
+    parameters:
+    - schema:
+        type: string
+      name: scan_id
+      in: path
+      required: true
+    get:
+      summary: Get list of unique assets for a scan.
+      tags:
+      - scans
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                - data
+                - total_assets
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ScanAssetListItemOptional'
+                  total_assets:
+                    type: integer
+                  total_host_assets:
+                    type: integer
+        '400':
+          $ref: '#/components/responses/MessageResponse'
+        '401':
+          $ref: '#/components/responses/MessageResponse'
+        '404':
+          $ref: '#/components/responses/MessageResponse'
+        '500':
+          $ref: '#/components/responses/MessageResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v1-scans-scan-id-assets
+      security:
+      - X-API-Key: []
+      description: List of all unique assets for a scan.
+      parameters:
+      - schema:
+          type: string
+        in: query
+        name: search
+        description: Search with host or port
+      - schema:
+          type: integer
+        in: query
+        name: limit
+        description: Limit the number of assets (Default 100)
+      - schema:
+          type: integer
+        in: query
+        name: offset
+        description: Offset the number of assets (Default 0)
   /v1/scans/{scan_id}/asset/export:
     parameters:
     - schema:
@@ -3378,6 +6144,153 @@ paths:
         in: query
         name: format
         description: supported format is csv, json, or raw (default json)
+  /v1/asset/enumerate/domains:
+    get:
+      summary: Get list of unique domains discovered in current month
+      tags:
+      - asset
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                - data
+                - workspace_domains
+                - total_domains
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/EnumerationDomainListItem'
+                  workspace_domains:
+                    type: integer
+                  total_domains:
+                    type: integer
+        '400':
+          $ref: '#/components/responses/MessageResponse'
+        '401':
+          $ref: '#/components/responses/MessageResponse'
+        '404':
+          $ref: '#/components/responses/MessageResponse'
+        '500':
+          $ref: '#/components/responses/MessageResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v1-asset-enumerate-domains
+      description: Get list of unique domains discovered in current month
+      parameters:
+      - schema:
+          type: string
+        in: query
+        name: search
+        description: Search with domain name
+      - schema:
+          type: integer
+        in: query
+        name: limit
+        description: Limit the number of domains (Default 100)
+      - schema:
+          type: integer
+        in: query
+        name: offset
+        description: Offset the number of domains (Default 0)
+  /v1/asset/enumerate/domains/export:
+    get:
+      summary: Export list of unique domains discovered in current month
+      tags:
+      - asset
+      responses:
+        '200':
+          description: OK
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+        '400':
+          $ref: '#/components/responses/MessageResponse'
+        '401':
+          $ref: '#/components/responses/MessageResponse'
+        '404':
+          $ref: '#/components/responses/MessageResponse'
+        '500':
+          $ref: '#/components/responses/MessageResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v1-asset-enumerate-domains-export
+      security:
+      - X-API-Key: []
+      description: Export list of unique domains discovered in current month.
+      parameters:
+      - schema:
+          type: string
+        in: query
+        name: search
+        description: Search with domain name
+      - schema:
+          type: string
+        in: query
+        name: format
+        description: supported format is csv, raw, or json (default json)
+    parameters: []
+  /v1/asset/enumerate/{enumerate_id}/domains:
+    parameters:
+    - schema:
+        type: string
+      name: enumerate_id
+      in: path
+      required: true
+    get:
+      summary: Get list of unique domains discovered in an enumeration
+      tags:
+      - asset
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                - data
+                - total_domains
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/EnumerationDomainListItem'
+                  total_domains:
+                    type: integer
+        '400':
+          $ref: '#/components/responses/MessageResponse'
+        '401':
+          $ref: '#/components/responses/MessageResponse'
+        '404':
+          $ref: '#/components/responses/MessageResponse'
+        '500':
+          $ref: '#/components/responses/MessageResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v1-asset-enumerate-enum-id-domains
+      description: Get list of unique domains discovered in an enumeration
+      parameters:
+      - schema:
+          type: string
+        in: query
+        name: search
+        description: Search with domain name
+      - schema:
+          type: integer
+        in: query
+        name: limit
+        description: Limit the number of domains (Default 100)
+      - schema:
+          type: integer
+        in: query
+        name: offset
+        description: Offset the number of domains (Default 0)
   /v1/asset/enumerate/{enumerate_id}/domains/export:
     parameters:
     - schema:
@@ -3421,6 +6334,32 @@ paths:
         in: query
         name: format
         description: supported format is csv, raw, or json (default json)
+  /v1/scans/token:
+    get:
+      summary: Get Scans Token
+      description: Get user scan token usage details
+      tags:
+      - scans
+      responses:
+        '200':
+          $ref: '#/components/responses/GetScansTokenResponse'
+        '400':
+          $ref: '#/components/responses/MessageResponse'
+        '401':
+          $ref: '#/components/responses/MessageResponse'
+        '404':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/MessageResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v1-scans-token
+      parameters:
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
   /v1/asset/{asset_id}/changelogs:
     parameters:
     - schema:
@@ -3493,6 +6432,468 @@ paths:
       security:
       - X-API-Key: []
       description: Get asset changelogs
+  /v1/asset/changelogs:
+    get:
+      summary: Get Asset Changelogs for all assets
+      tags:
+      - assets
+      responses:
+        '200':
+          $ref: '#/components/responses/GetAssetChangelogsResponse'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v1-asset-changelogs
+      parameters:
+      - schema:
+          type: string
+          enum:
+          - last_day
+          - last_week
+          - last_month
+          - last_3_months
+          - last_6_months
+          - last_12_months
+          - all_time
+          default: all_time
+        in: query
+        name: time
+        description: time filter to select
+      - schema:
+          type: string
+        in: query
+        name: event_type
+        description: comma separated event_type e.g. event_type=vul_status,vul_status_change
+      - schema:
+          type: string
+        in: query
+        name: sort_asc
+        description: comma separated ascending sorting e.g sort_asc=created_at,severity
+      - schema:
+          type: string
+        in: query
+        name: sort_desc
+        description: comma separated descending sorting e.g sort_desc=created_at,severity
+      - schema:
+          type: integer
+        in: query
+        name: limit
+        description: limit the number of changelogs returned
+      - schema:
+          type: integer
+        in: query
+        name: offset
+        description: offset the number of changelogs returned
+      - schema:
+          type: string
+        in: header
+        name: X-Team-Id
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+      security:
+      - X-API-Key: []
+      description: Get asset changelogs
+  /v1/asset/{asset_id}:
+    parameters:
+    - schema:
+        type: integer
+        format: int64
+      name: asset_id
+      in: path
+      required: true
+    get:
+      summary: Get enumerated asset details
+      tags:
+      - assets
+      responses:
+        '200':
+          $ref: '#/components/responses/GetAssetResponse'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '404':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v1-asset-id
+      parameters:
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+    delete:
+      summary: Delete enumerated asset
+      tags:
+      - assets
+      responses:
+        '200':
+          $ref: '#/components/responses/MessageResponse'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: delete-v1-asset-asset_id
+      parameters:
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+    patch:
+      summary: Update asset details
+      tags:
+      - assets
+      responses:
+        '200':
+          $ref: '#/components/responses/MessageResponse'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: patch-v1-asset-asset_id
+      requestBody:
+        $ref: '#/components/requestBodies/UpdateEnumeratedAssetRequest'
+      parameters:
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+  /v1/asset:
+    delete:
+      summary: Delete asset by filters
+      tags:
+      - assets
+      responses:
+        '200':
+          $ref: '#/components/responses/AssetCountResponse'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '404':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: delete-v1-asset
+      security:
+      - X-API-Key: []
+      description: Delete asset by filters
+      parameters:
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+      requestBody:
+        $ref: '#/components/requestBodies/DeleteAssetsRequest'
+  /v1/asset/labels:
+    patch:
+      summary: Update Asset Labels
+      tags:
+      - assets
+      responses:
+        '200':
+          $ref: '#/components/responses/AssetCountResponse'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '404':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: patch-v1-asset-labels
+      parameters:
+      - schema:
+          type: string
+          enum:
+          - append
+          - replace
+          - delete
+          default: append
+        in: query
+        name: update_type
+        description: Append or Replace update_type
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+      requestBody:
+        $ref: '#/components/requestBodies/UpdateAssetLabelsRequest'
+  /v1/asset/{asset_id}/labels:
+    parameters:
+    - schema:
+        type: integer
+        format: int64
+      name: asset_id
+      in: path
+      required: true
+    post:
+      summary: Add labels to an asset
+      tags:
+      - assets
+      responses:
+        '200':
+          $ref: '#/components/responses/MessageResponse'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '404':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: post-v1-asset-id-labels
+      parameters:
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+      requestBody:
+        $ref: '#/components/requestBodies/AssetIdLabelsRequest'
+    patch:
+      summary: Modify labels of an asset
+      tags:
+      - assets
+      responses:
+        '200':
+          $ref: '#/components/responses/MessageResponse'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '404':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: patch-v1-asset-id-labels
+      parameters:
+      - schema:
+          type: string
+          enum:
+          - append
+          - replace
+          - delete
+          default: append
+        in: query
+        name: update_type
+        description: Append or Replace update_type
+      requestBody:
+        $ref: '#/components/requestBodies/AssetIdLabelsRequest'
+    delete:
+      summary: Delete labels of an asset
+      tags:
+      - assets
+      responses:
+        '200':
+          $ref: '#/components/responses/MessageResponse'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '404':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: delete-v1-asset-id-labels
+      parameters:
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+  /v1/asset/enumerate/{enumerate_id}/stats:
+    parameters:
+    - schema:
+        type: string
+      name: enumerate_id
+      in: path
+      required: true
+    - schema:
+        $ref: '#/components/schemas/TimeRangeQueryParameter'
+        default: all_time
+      in: query
+      name: time
+      description: time filter to select
+    - schema:
+        type: string
+        format: date
+      in: query
+      name: start_date
+      description: time filter start date
+    - schema:
+        type: string
+        format: date
+      in: query
+      name: end_date
+      description: time filter end date
+    - schema:
+        type: boolean
+      in: query
+      name: only_dns
+      description: Query only dns FQDN records
+    - schema:
+        type: boolean
+      in: query
+      name: only_ip
+      description: Query only dns IP records
+    get:
+      summary: Get enumeration stats
+      tags:
+      - enumerations
+      responses:
+        '200':
+          $ref: '#/components/responses/EnumerationStatsResponse'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v1-asset-enumerate-enumerate_id-stats
+      parameters:
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+  /v1/asset/domain/{domain_name}/stats:
+    parameters:
+    - schema:
+        type: string
+      name: domain_name
+      in: path
+      required: true
+    - schema:
+        $ref: '#/components/schemas/TimeRangeQueryParameter'
+        default: all_time
+      in: query
+      name: time
+      description: time filter to select
+    - schema:
+        type: string
+        format: date
+      in: query
+      name: start_date
+      description: time filter start date
+    - schema:
+        type: string
+        format: date
+      in: query
+      name: end_date
+      description: time filter end date
+    get:
+      summary: Get domain stats
+      tags:
+      - enumerations
+      responses:
+        '200':
+          $ref: '#/components/responses/EnumerationStatsResponse'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v1-asset-domain-domain_name-stats
+      parameters:
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+  /v1/asset/enumerate/stats:
+    parameters:
+    - schema:
+        $ref: '#/components/schemas/TimeRangeQueryParameter'
+        default: all_time
+      in: query
+      name: time
+      description: time filter to select
+    - schema:
+        type: string
+        format: date
+      in: query
+      name: start_date
+      description: time filter start date
+    - schema:
+        type: string
+        format: date
+      in: query
+      name: end_date
+      description: time filter end date
+    - schema:
+        type: boolean
+      in: query
+      name: only_dns
+      description: Query only dns FQDN records
+    - schema:
+        type: boolean
+      in: query
+      name: only_ip
+      description: Query only dns IP records
+    get:
+      summary: Get all enumeration stats
+      tags:
+      - enumerations
+      responses:
+        '200':
+          $ref: '#/components/responses/EnumerationStatsResponse'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v1-asset-enumerate-stats
+      parameters:
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+  /v1/admin/team:
+    parameters:
+    - in: header
+      name: X-Team-ID
+      required: true
+      schema:
+        type: string
   /v1/asset/enumerate/{enumerate_id}/config:
     parameters:
     - schema:
@@ -3561,6 +6962,524 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/EnumerationConfig'
+  /v1/user/usage:
+    get:
+      summary: Get API Services Usage
+      tags:
+      - usage
+      responses:
+        '200':
+          $ref: '#/components/responses/UsageResponse'
+        '400':
+          $ref: '#/components/responses/MessageResponse'
+        '401':
+          $ref: '#/components/responses/MessageResponse'
+        '500':
+          $ref: '#/components/responses/MessageResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v1-user-usage
+      requestBody:
+        $ref: '#/components/requestBodies/UsageRequest'
+      security:
+      - X-API-Key: []
+      parameters:
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+    parameters: []
+  /v1/asset/enumerate/filters:
+    get:
+      summary: Group assets by filters
+      tags:
+      - enumerations
+      responses:
+        '200':
+          $ref: '#/components/responses/GetEnumerateFiltersResponse'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v1-asset-enumerate-filters
+      parameters:
+      - in: query
+        name: offset
+        schema:
+          type: integer
+        description: The number of items to skip before starting to collect the result set
+      - in: query
+        name: limit
+        schema:
+          type: integer
+        description: The numbers of items to return
+      - in: query
+        name: host
+        schema:
+          type: string
+      - in: query
+        name: port
+        schema:
+          type: string
+      - in: query
+        name: ip
+        schema:
+          type: string
+      - in: query
+        name: cname
+        schema:
+          type: string
+      - in: query
+        name: technologies
+        schema:
+          type: string
+      - in: query
+        name: status_code
+        schema:
+          type: string
+      - in: query
+        name: content_length
+        schema:
+          type: string
+      - in: query
+        name: domain
+        schema:
+          type: string
+      - in: query
+        name: title
+        schema:
+          type: string
+      - in: query
+        name: webserver
+        schema:
+          type: string
+      - in: query
+        name: favicon
+        schema:
+          type: string
+      - in: query
+        name: labels
+        schema:
+          type: string
+      - schema:
+          $ref: '#/components/schemas/EnumerateFilterTypes'
+        in: query
+        name: group_by
+        description: Group by type. e.g. - host, port, favicon.
+        required: true
+      - schema:
+          type: string
+          enum:
+          - cname
+          - content_length
+          - favicon
+          - host
+          - ip
+          - port
+          - status_code
+          - technologies
+          - title
+          - webserver
+        in: query
+        name: sort_asc
+        description: supported sort fields
+      - schema:
+          type: string
+          enum:
+          - cname
+          - content_length
+          - favicon
+          - host
+          - ip
+          - port
+          - status_code
+          - technologies
+          - title
+          - webserver
+        in: query
+        name: sort_desc
+        description: supported sort fields
+      - schema:
+          $ref: '#/components/schemas/TimeRangeQueryParameter'
+          default: all_time
+        in: query
+        name: time
+        description: time filter to select
+      - schema:
+          type: string
+          format: date
+        in: query
+        name: start_date
+        description: time filter start date
+      - schema:
+          type: string
+          format: date
+        in: query
+        name: end_date
+        description: time filter end date
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+      - schema:
+          type: boolean
+        in: query
+        name: is_screenshot
+      - schema:
+          type: boolean
+        in: query
+        name: is_tech
+      - schema:
+          type: boolean
+        in: query
+        name: is_favicon
+        description: Filter items with favicon
+      - schema:
+          type: boolean
+        in: query
+        name: only_dns
+        description: Query only dns FQDN records
+      - schema:
+          type: boolean
+        in: query
+        name: only_ip
+        description: Query only dns IP records
+      - schema:
+          type: string
+        in: query
+        name: custom_filter
+        description: Filter by custom filter. Double encode the query string.
+  /v1/asset/enumerate/{enumerate_id}/filters:
+    parameters:
+    - schema:
+        type: string
+      name: enumerate_id
+      in: path
+      required: true
+    get:
+      summary: Group assets by filters for an enumeration
+      tags:
+      - enumerations
+      responses:
+        '200':
+          $ref: '#/components/responses/GetEnumerateFiltersResponse'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v1-asset-enumerate-id-filters
+      parameters:
+      - in: query
+        name: offset
+        schema:
+          type: integer
+        description: The number of items to skip before starting to collect the result set
+      - in: query
+        name: limit
+        schema:
+          type: integer
+        description: The numbers of items to return
+      - in: query
+        name: host
+        schema:
+          type: string
+      - in: query
+        name: port
+        schema:
+          type: string
+      - in: query
+        name: ip
+        schema:
+          type: string
+      - in: query
+        name: cname
+        schema:
+          type: string
+      - in: query
+        name: technologies
+        schema:
+          type: string
+      - in: query
+        name: status_code
+        schema:
+          type: string
+      - in: query
+        name: content_length
+        schema:
+          type: string
+      - in: query
+        name: domain
+        schema:
+          type: string
+      - in: query
+        name: title
+        schema:
+          type: string
+      - in: query
+        name: webserver
+        schema:
+          type: string
+      - in: query
+        name: labels
+        schema:
+          type: string
+      - in: query
+        name: favicon
+        schema:
+          type: string
+      - schema:
+          $ref: '#/components/schemas/EnumerateFilterTypes'
+        in: query
+        name: group_by
+        description: Group by type. e.g. - host, port, favicon.
+        required: true
+      - schema:
+          type: string
+          enum:
+          - cname
+          - content_length
+          - favicon
+          - host
+          - ip
+          - port
+          - status_code
+          - technologies
+          - title
+          - webserver
+          - labels
+        in: query
+        name: sort_asc
+        description: supported sort fields
+      - schema:
+          type: string
+          enum:
+          - cname
+          - content_length
+          - favicon
+          - host
+          - ip
+          - port
+          - status_code
+          - technologies
+          - title
+          - webserver
+          - labels
+        in: query
+        name: sort_desc
+        description: supported sort fields
+      - schema:
+          $ref: '#/components/schemas/TimeRangeQueryParameter'
+          default: all_time
+        in: query
+        name: time
+        description: time filter to select
+      - schema:
+          type: string
+          format: date
+        in: query
+        name: start_date
+        description: time filter start date
+      - schema:
+          type: string
+          format: date
+        in: query
+        name: end_date
+        description: time filter end date
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+      - schema:
+          type: boolean
+        in: query
+        name: is_screenshot
+      - schema:
+          type: boolean
+        in: query
+        name: is_tech
+      - schema:
+          type: boolean
+        in: query
+        name: is_favicon
+        description: Filter items with favicon
+      - schema:
+          type: boolean
+        in: query
+        name: only_dns
+        description: Query only dns FQDN records
+      - schema:
+          type: boolean
+        in: query
+        name: only_ip
+        description: Query only dns IP records
+      - schema:
+          type: string
+        in: query
+        name: custom_filter
+        description: Filter by custom filter. Double encode the query string.
+  /v1/asset/domain/{domain_name}/filters:
+    parameters:
+    - schema:
+        type: string
+      name: domain_name
+      in: path
+      required: true
+    get:
+      summary: Group assets by filters for an domain
+      tags:
+      - enumerations
+      - domains
+      responses:
+        '200':
+          $ref: '#/components/responses/GetEnumerateFiltersResponse'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v1-asset-domain-domain-name-filters
+      parameters:
+      - in: query
+        name: offset
+        schema:
+          type: integer
+        description: The number of items to skip before starting to collect the result set
+      - in: query
+        name: limit
+        schema:
+          type: integer
+        description: The numbers of items to return
+      - in: query
+        name: host
+        schema:
+          type: string
+      - in: query
+        name: port
+        schema:
+          type: string
+      - in: query
+        name: ip
+        schema:
+          type: string
+      - in: query
+        name: cname
+        schema:
+          type: string
+      - in: query
+        name: technologies
+        schema:
+          type: string
+      - in: query
+        name: status_code
+        schema:
+          type: string
+      - in: query
+        name: content_length
+        schema:
+          type: string
+      - in: query
+        name: domain
+        schema:
+          type: array
+          items:
+            type: string
+      - in: query
+        name: title
+        schema:
+          type: string
+      - in: query
+        name: webserver
+        schema:
+          type: string
+      - in: query
+        name: labels
+        schema:
+          type: string
+      - in: query
+        name: favicon
+        schema:
+          type: string
+      - schema:
+          $ref: '#/components/schemas/EnumerateFilterTypes'
+        in: query
+        name: group_by
+        description: Group by type. e.g. - host, port, favicon.
+        required: true
+      - schema:
+          type: string
+          enum:
+          - cname
+          - content_length
+          - favicon
+          - host
+          - ip
+          - port
+          - status_code
+          - technologies
+          - title
+          - webserver
+          - labels
+        in: query
+        name: sort_asc
+        description: supported sort fields
+      - schema:
+          type: string
+          enum:
+          - cname
+          - content_length
+          - favicon
+          - host
+          - ip
+          - port
+          - status_code
+          - technologies
+          - title
+          - webserver
+          - labels
+        in: query
+        name: sort_desc
+        description: supported sort fields
+      - schema:
+          $ref: '#/components/schemas/TimeRangeQueryParameter'
+          default: all_time
+        in: query
+        name: time
+        description: time filter to select
+      - schema:
+          type: string
+          format: date
+        in: query
+        name: start_date
+        description: time filter start date
+      - schema:
+          type: string
+          format: date
+        in: query
+        name: end_date
+        description: time filter end date
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+      - schema:
+          type: boolean
+        in: query
+        name: is_screenshot
   /v1/asset/enumerate/export:
     parameters:
     - schema:
@@ -3774,6 +7693,1304 @@ paths:
                   type: string
                 id:
                   type: string
+  /v1/automations:
+    get:
+      summary: Get Automations
+      tags:
+      - automations
+      responses:
+        '200':
+          $ref: '#/components/responses/GetAutomationsListResponse'
+        '400':
+          $ref: '#/components/responses/MessageResponse'
+        '401':
+          $ref: '#/components/responses/MessageResponse'
+        '500':
+          $ref: '#/components/responses/MessageResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v1-automations
+      security:
+      - X-API-Key: []
+      parameters:
+      - schema:
+          type: integer
+        in: query
+        name: offset
+      - schema:
+          type: integer
+        in: query
+        name: limit
+      - schema:
+          type: string
+        in: header
+        name: X-Team-Id
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+    post:
+      summary: Create Automation
+      tags:
+      - automations
+      responses:
+        '200':
+          $ref: '#/components/responses/MessageResponse'
+        '201':
+          $ref: '#/components/responses/MessageResponse'
+        '400':
+          $ref: '#/components/responses/MessageResponse'
+        '401':
+          $ref: '#/components/responses/MessageResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: post-v1-automations
+      security:
+      - X-API-Key: []
+      requestBody:
+        $ref: '#/components/requestBodies/AddAutomation'
+      parameters:
+      - schema:
+          type: string
+        in: header
+        name: X-Team-Id
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+  /v1/automations/{event}:
+    parameters:
+    - schema:
+        type: string
+      name: event
+      in: path
+      required: true
+    get:
+      summary: Get Automation
+      tags:
+      - automations
+      responses:
+        '200':
+          $ref: '#/components/responses/GetAutomationIdResponse'
+        '400':
+          $ref: '#/components/responses/MessageResponse'
+        '401':
+          $ref: '#/components/responses/MessageResponse'
+        '404':
+          $ref: '#/components/responses/MessageResponse'
+        '500':
+          $ref: '#/components/responses/MessageResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v1-automations-event
+      parameters:
+      - schema:
+          type: string
+        in: header
+        name: X-Team-Id
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+    patch:
+      summary: Update Automation
+      tags:
+      - automations
+      responses:
+        '200':
+          $ref: '#/components/responses/MessageResponse'
+        '400':
+          $ref: '#/components/responses/MessageResponse'
+        '401':
+          $ref: '#/components/responses/MessageResponse'
+        '404':
+          $ref: '#/components/responses/MessageResponse'
+        '500':
+          $ref: '#/components/responses/MessageResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: patch-v1-automations-event
+      requestBody:
+        $ref: '#/components/requestBodies/UpdateAutomationRequest'
+      parameters:
+      - schema:
+          type: string
+        in: header
+        name: X-Team-Id
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+    delete:
+      summary: Delete Automation
+      tags:
+      - automations
+      responses:
+        '200':
+          $ref: '#/components/responses/MessageResponse'
+        '400':
+          $ref: '#/components/responses/MessageResponse'
+        '401':
+          $ref: '#/components/responses/MessageResponse'
+        '404':
+          $ref: '#/components/responses/MessageResponse'
+        '500':
+          $ref: '#/components/responses/MessageResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: delete-v1-automations-event
+      parameters:
+      - schema:
+          type: string
+        in: header
+        name: X-Team-Id
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+  /v1/asset/exposures/metrics:
+    get:
+      summary: Get exposure metrics
+      tags:
+      - asset
+      parameters:
+      - in: query
+        name: interval
+        schema:
+          type: string
+          enum:
+          - monthly
+          default: monthly
+        required: false
+        description: The time interval for the metrics
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+      responses:
+        '200':
+          $ref: '#/components/responses/ExposureMetricsResponse'
+        '400':
+          $ref: '#/components/responses/MessageResponse'
+        '401':
+          $ref: '#/components/responses/MessageResponse'
+        '404':
+          $ref: '#/components/responses/MessageResponse'
+        '500':
+          $ref: '#/components/responses/MessageResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v1-asset-exposures-metrics
+      security:
+      - X-API-Key: []
+  /v1/scans/vulns/exposures/metrics:
+    get:
+      summary: Get scan vuln exposure metrics
+      tags:
+      - scan
+      parameters:
+      - in: query
+        name: interval
+        schema:
+          type: string
+          enum:
+          - monthly
+          default: monthly
+        required: true
+        description: The time interval for the metrics
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+      responses:
+        '200':
+          $ref: '#/components/responses/ScanExposureMetricsResponse'
+        '400':
+          $ref: '#/components/responses/MessageResponse'
+        '401':
+          $ref: '#/components/responses/MessageResponse'
+        '404':
+          $ref: '#/components/responses/MessageResponse'
+        '500':
+          $ref: '#/components/responses/MessageResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v1-scans-vulns-exposures-metrics
+      security:
+      - X-API-Key: []
+  /v1/scans/vulns/regression/metrics:
+    get:
+      summary: Get scan vuln regression metrics
+      tags:
+      - scan
+      parameters:
+      - in: query
+        name: interval
+        schema:
+          type: string
+          enum:
+          - monthly
+          default: monthly
+        required: true
+        description: The time interval for the metrics
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+      responses:
+        '200':
+          $ref: '#/components/responses/ScanRegressionRemediationMetricsResponse'
+        '400':
+          $ref: '#/components/responses/MessageResponse'
+        '401':
+          $ref: '#/components/responses/MessageResponse'
+        '404':
+          $ref: '#/components/responses/MessageResponse'
+        '500':
+          $ref: '#/components/responses/MessageResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v1-scans-vulns-regression-metrics
+      security:
+      - X-API-Key: []
+  /v1/scans/vulns/remediation/metrics:
+    get:
+      summary: Get scan vuln remediation metrics
+      tags:
+      - scan
+      parameters:
+      - in: query
+        name: interval
+        schema:
+          type: string
+          enum:
+          - monthly
+          default: monthly
+        required: true
+        description: The time interval for the metrics
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+      responses:
+        '200':
+          $ref: '#/components/responses/ScanRegressionRemediationMetricsResponse'
+        '400':
+          $ref: '#/components/responses/MessageResponse'
+        '401':
+          $ref: '#/components/responses/MessageResponse'
+        '404':
+          $ref: '#/components/responses/MessageResponse'
+        '500':
+          $ref: '#/components/responses/MessageResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v1-scans-vulns-remediation-metrics
+      security:
+      - X-API-Key: []
+  /v1/scans/validate:
+    post:
+      summary: Validate scan token before starting scan
+      tags:
+      - scan
+      parameters:
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  unique_asset_to_scan:
+                    type: integer
+                    format: int64
+                  total_asset_to_scan:
+                    type: integer
+                    format: int64
+                required:
+                - unique_asset_to_scan
+                - total_asset_to_scan
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '404':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                targets:
+                  type: array
+                  items:
+                    type: string
+                enumeration_ids:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/EnumerationIDTypes'
+      operationId: post-v1-scans-validate
+      security:
+      - X-API-Key: []
+  /v1/integration/oauth/{name}/generate-url:
+    post:
+      summary: Get OAuth URL for the service provider
+      tags:
+      - oauth
+      parameters:
+      - schema:
+          type: string
+        name: name
+        in: path
+        required: true
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  url:
+                    type: string
+                required:
+                - url
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: post-v1-generate-oauth-url
+      security:
+      - X-API-Key: []
+  /v1/integration/oauth/{name}/exchange-token:
+    post:
+      summary: Exchange code for access token
+      tags:
+      - oauth
+      parameters:
+      - schema:
+          type: string
+        name: name
+        in: path
+        required: true
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                code:
+                  type: string
+                state:
+                  type: string
+                installation_id:
+                  type: string
+              required:
+              - code
+              - state
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                - message
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: post-v1-exchange-oauth-token
+      security:
+      - X-API-Key: []
+  /v1/integration/oauth/{name}/status:
+    get:
+      parameters:
+      - schema:
+          type: string
+        name: name
+        in: path
+        required: true
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+      summary: Get OAuth status
+      tags:
+      - oauth
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/OAuthStatus'
+                  metadata:
+                    $ref: '#/components/schemas/OAuthMetadata'
+                  config_id:
+                    type: string
+                required:
+                - status
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v1-integration-oauth-status
+      security:
+      - X-API-Key: []
+  /v1/integration/oauth/{name}/revoke:
+    delete:
+      summary: Revoke OAuth token
+      tags:
+      - oauth
+      parameters:
+      - schema:
+          type: string
+        name: name
+        in: path
+        required: true
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                - message
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: delete-v1-integration-oauth-revoke
+      security:
+      - X-API-Key: []
+  /v1/billing-cycles:
+    get:
+      summary: Get the monthly billing cycle dates
+      tags:
+      - billing
+      responses:
+        '200':
+          $ref: '#/components/responses/BillingCycleResponse'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '404':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v1-billing-cycles
+      parameters:
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+  /v1/scans/remediation-efficiency:
+    get:
+      summary: Get remediation efficiency stats
+      tags:
+      - scan
+      responses:
+        '200':
+          $ref: '#/components/responses/GetRemediationEfficiencyResponse'
+        '400':
+          $ref: '#/components/responses/MessageResponse'
+        '401':
+          $ref: '#/components/responses/MessageResponse'
+        '404':
+          $ref: '#/components/responses/MessageResponse'
+        '500':
+          $ref: '#/components/responses/MessageResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v1-scans-remediation-efficiency
+      parameters:
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+  /v1/domain/search:
+    get:
+      summary: Domain & Organization Name Search
+      tags:
+      - chaos
+      responses:
+        '200':
+          $ref: '#/components/responses/DomainSearchResults'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '404':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: domain-search
+      parameters:
+      - schema:
+          type: string
+        in: query
+        name: query
+        description: Search query for domain or organization name
+        required: true
+      - schema:
+          type: integer
+        in: query
+        name: limit
+        description: Number of results to return
+      - schema:
+          type: array
+          items:
+            type: string
+        in: query
+        name: fields
+        description: Fields to include in response (CSV)
+      - schema:
+          type: string
+          enum:
+          - all
+          - domains
+          - orgs
+        in: query
+        name: scope
+        description: Scope of search
+  /v1/organization/search:
+    get:
+      summary: Get Organization by Domain
+      tags:
+      - chaos
+      responses:
+        '200':
+          $ref: '#/components/responses/OrganizationSearchResults'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '404':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: organization-search
+      parameters:
+      - schema:
+          type: string
+        in: query
+        name: domain
+        description: Domain name to search and retrieve associated organization information
+        required: true
+      - schema:
+          type: integer
+        in: query
+        name: limit
+        description: Number of results to return
+      - schema:
+          type: integer
+        in: query
+        name: offset
+        description: Pagination Offset
+  /v1/scans/vulns/score/metrics:
+    get:
+      summary: Get Vuln Score Metrics
+      tags:
+      - vulns
+      parameters:
+      - in: query
+        name: interval
+        schema:
+          type: string
+          enum:
+          - monthly
+          default: monthly
+        description: The time interval for the metrics
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+      responses:
+        '200':
+          $ref: '#/components/responses/VulnScoreMetricsResponse'
+        '400':
+          $ref: '#/components/responses/MessageResponse'
+        '401':
+          $ref: '#/components/responses/MessageResponse'
+        '404':
+          $ref: '#/components/responses/MessageResponse'
+        '500':
+          $ref: '#/components/responses/MessageResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v1-scans-vulns-score-metrics
+  /v1/asset/enumerate/{enumerate_id}/categories:
+    parameters:
+    - schema:
+        type: string
+      in: header
+      description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+      name: X-Team-Id
+    - schema:
+        type: string
+      name: enumerate_id
+      in: path
+      required: true
+    - schema:
+        type: string
+        enum:
+        - last_day
+        - last_week
+        - last_month
+        - last_3_months
+        - last_6_months
+        - last_12_months
+        - all_time
+        default: all_time
+      in: query
+      name: time
+      description: time filter to select
+    - schema:
+        type: string
+        format: date
+      in: query
+      name: start_date
+      description: time filter start date
+    - schema:
+        type: string
+        format: date
+      in: query
+      name: end_date
+      description: time filter end date
+    - schema:
+        type: boolean
+      in: query
+      name: show_hosts
+    - schema:
+        type: array
+        items:
+          type: string
+      in: query
+      name: domain
+    get:
+      summary: Get categories for specific enumeration
+      tags:
+      - enumeration
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                - asset_categories
+                properties:
+                  asset_categories:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/AssetCategory'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v1-asset-enumerate-enumerate-id-categories
+      security:
+      - X-API-Key: []
+      parameters: []
+  /v1/asset/enumerate/categories:
+    parameters:
+    - schema:
+        type: string
+      in: header
+      description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+      name: X-Team-Id
+    - schema:
+        type: string
+        enum:
+        - last_day
+        - last_week
+        - last_month
+        - last_3_months
+        - last_6_months
+        - last_12_months
+        - all_time
+        default: all_time
+      in: query
+      name: time
+      description: time filter to select
+    - schema:
+        type: string
+        format: date
+      in: query
+      name: start_date
+      description: time filter start date
+    - schema:
+        type: string
+        format: date
+      in: query
+      name: end_date
+      description: time filter end date
+    - schema:
+        type: boolean
+      in: query
+      name: show_hosts
+    - schema:
+        type: array
+        items:
+          type: string
+      in: query
+      name: domain
+    get:
+      summary: Get categories for all enumerations
+      tags:
+      - enumeration
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                - asset_categories
+                properties:
+                  asset_categories:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/AssetCategory'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v1-asset-enumerate-categories
+      security:
+      - X-API-Key: []
+  /v1/asset/domain/{domain_name}:
+    parameters:
+    - schema:
+        type: string
+      name: domain_name
+      in: path
+      required: true
+    get:
+      summary: Get Enumeration Domain Contents
+      tags:
+      - enumerations
+      - domains
+      responses:
+        '200':
+          $ref: '#/components/responses/GetEnumerateIdContents'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '403':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v1-asset-domain-domain_name-contents
+      parameters:
+      - schema:
+          type: integer
+          default: 0
+        in: query
+        name: offset
+        description: The number of items to skip before starting to collect the result set
+      - schema:
+          type: integer
+          default: 100
+        in: query
+        name: limit
+        description: The numbers of items to return
+      - schema:
+          type: boolean
+        in: query
+        name: is_tech
+        description: Return records that have technologies
+      - schema:
+          type: boolean
+        in: query
+        name: is_favicon
+        description: Return the records that have favicon
+      - schema:
+          type: string
+        name: search
+        in: query
+        description: Search on the content name
+      - schema:
+          type: string
+        in: query
+        name: labels
+        description: Filter by comma separated labels, e.g-> labels=p1,p2
+      - schema:
+          type: boolean
+        in: query
+        name: is_new
+        description: Filter by new content
+      - schema:
+          type: string
+        in: query
+        name: host
+        description: Filter by comma separated hosts, e.g-> host=p1,p2
+      - schema:
+          type: string
+        in: query
+        name: port
+        description: Filter by comma separated ports, e.g-> port=p1,p2
+      - schema:
+          type: string
+        in: query
+        name: status_code
+        description: Filter by comma separated status codes, e.g-> status_code=p1,p2
+      - schema:
+          type: string
+        in: query
+        name: title
+        description: Filter by comma separated titles, e.g-> title=p1,p2
+      - schema:
+          type: string
+        in: query
+        name: content_length
+        description: Filter by comma separated content lengths, e.g-> content_length=p1,p2
+      - schema:
+          type: string
+        in: query
+        name: cname
+        description: cname to filter
+      - schema:
+          type: string
+        in: query
+        name: technologies
+        description: technologies to filter
+      - schema:
+          type: string
+        in: query
+        name: ip
+        description: ips to filter
+      - schema:
+          type: string
+        in: query
+        name: sort_asc
+        description: comma separated ascending sorting e.g sort_asc=created_at,name
+      - schema:
+          type: string
+        in: query
+        name: sort_desc
+        description: comma separated descending sorting e.g sort_desc=created_at,name
+      - schema:
+          type: boolean
+        in: query
+        name: is_screenshot
+        description: asset with screenshots
+      - schema:
+          $ref: '#/components/schemas/TimeRangeQueryParameter'
+          default: all_time
+        in: query
+        name: time
+        description: time filter to select
+      - schema:
+          type: string
+          format: date
+        in: query
+        name: start_date
+        description: time filter start date
+      - schema:
+          type: string
+          format: date
+        in: query
+        name: end_date
+        description: time filter end date
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+      - schema:
+          type: string
+        in: query
+        name: custom_filter
+        description: custom query to filter. double encode the query string.
+      - schema:
+          type: string
+        in: query
+        name: favicon
+        description: Filter by comma separated favicons, e.g-> favicon=p1,p2
+      security:
+      - X-API-Key: []
+      description: Get enumeration content by domain_name
+  /v1/asset/domain/{domain_name}/export:
+    parameters:
+    - schema:
+        type: string
+      name: domain_name
+      in: path
+      required: true
+    - schema:
+        type: boolean
+      in: query
+      name: async
+    get:
+      summary: Export Enumeration of user by domain
+      tags:
+      - enumerations
+      responses:
+        '200':
+          description: OK
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  export_id:
+                    type: string
+                required:
+                - export_id
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v1-asset-domain-domain_name-export
+      parameters:
+      - schema:
+          $ref: '#/components/schemas/EnumExportFormats'
+        in: query
+        name: format
+      - schema:
+          type: string
+        name: search
+        in: query
+        description: Search on the content name
+      - schema:
+          type: string
+        in: query
+        name: labels
+        description: Filter by comma separated labels, e.g-> labels=p1,p2
+      - schema:
+          type: boolean
+        in: query
+        name: is_new
+        description: Filter by new content
+      - schema:
+          type: string
+        in: query
+        name: host
+        description: Filter by comma separated labels, e.g-> host=p1,p2
+      - schema:
+          type: string
+        in: query
+        name: port
+        description: Filter by port separated labels, e.g-> port=p1,p2
+      - schema:
+          type: string
+        in: query
+        name: status_code
+        description: Filter by status code separated labels, e.g-> status_code=p1,p2
+      - schema:
+          type: string
+        in: query
+        name: title
+        description: Filter by title separated labels, e.g-> title=p1,p2
+      - schema:
+          type: string
+        in: query
+        name: content_length
+        description: Filter by content length separated labels, e.g-> content_length=p1,p2
+      - schema:
+          type: string
+        in: query
+        name: domain
+        description: Filter by domain names separated labels, e.g-> domain=domain1.com,domain2.com
+      - schema:
+          type: string
+        in: query
+        name: cname
+        description: cname to filter
+      - schema:
+          type: string
+        in: query
+        name: technologies
+        description: technologies to filter
+      - schema:
+          type: string
+        in: query
+        name: sort_asc
+        description: comma separated ascending sorting e.g sort_asc=created_at,name
+      - schema:
+          type: string
+        in: query
+        name: sort_desc
+      - schema:
+          $ref: '#/components/schemas/TimeRangeQueryParameter'
+          default: all_time
+        in: query
+        name: time
+        description: time filter to select
+      - schema:
+          type: string
+          format: date
+        in: query
+        name: start_date
+        description: time filter start date
+      - schema:
+          type: string
+          format: date
+        in: query
+        name: end_date
+        description: time filter end date
+      - schema:
+          type: string
+        in: header
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+        name: X-Team-Id
+      - schema:
+          type: string
+        in: query
+        name: custom_filter
+        description: custom query to filter. double encode the query string.
+      - schema:
+          type: boolean
+        in: query
+        name: is_screenshot
+      - schema:
+          type: string
+        in: query
+        name: ip
+        description: ips to filter
+      - schema:
+          type: string
+        in: query
+        name: favicon
+        description: Filter by comma separated favicons, e.g-> favicon=p1,p2
+      security:
+      - X-API-Key: []
+      description: Export enumeration content by domain
+  /v2/template:
+    get:
+      summary: Get template metadata
+      tags: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                  results:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/TemplateData'
+                  total:
+                    type: integer
+        '400':
+          $ref: '#/components/responses/MessageResponse'
+        '401':
+          $ref: '#/components/responses/MessageResponse'
+        '404':
+          $ref: '#/components/responses/MessageResponse'
+        '500':
+          $ref: '#/components/responses/MessageResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v2-template
+      description: Get user templates
+      security:
+      - X-API-Key: []
+      parameters:
+      - schema:
+          type: string
+        in: header
+        name: X-Team-Id
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+      - in: query
+        name: scope
+        schema:
+          type: string
+      - schema:
+          type: integer
+        in: query
+        name: limit
+      - schema:
+          type: integer
+        in: query
+        name: offset
+      - schema:
+          type: array
+          items:
+            type: string
+        description: List of fields to return(comma separated)
+        in: query
+        name: fields
+      - schema:
+          type: string
+        in: query
+        name: sort_desc
+      - schema:
+          type: string
+        in: query
+        name: sort_asc
+      - schema:
+          type: array
+          items:
+            type: string
+          uniqueItems: false
+          minItems: 0
+        in: query
+        name: template-ids
+        allowEmptyValue: false
+      - schema:
+          type: array
+          items:
+            type: string
+        in: query
+        name: id
+      - schema:
+          type: array
+          items:
+            type: string
+        in: query
+        name: exclude-id
+      - schema:
+          type: array
+          items:
+            type: string
+        in: query
+        name: tags
+      - schema:
+          type: array
+          items:
+            type: string
+        in: query
+        name: include-tags
+      - schema:
+          type: array
+          items:
+            type: string
+        in: query
+        name: exclude-tags
+      - schema:
+          type: array
+          items:
+            type: string
+        in: query
+        name: severity
+      - schema:
+          type: array
+          items:
+            type: string
+        in: query
+        name: exclude-severity
+      - schema:
+          type: array
+          items:
+            type: string
+        in: query
+        name: type
+      - schema:
+          type: array
+          items:
+            type: string
+        in: query
+        name: exclude-type
+      - schema:
+          type: array
+          items:
+            type: string
+        in: query
+        name: templates
+      - schema:
+          type: array
+          items:
+            type: string
+        in: query
+        name: exclude-templates
+      - schema:
+          type: string
+        in: query
+        name: profile_name
+      - schema:
+          type: boolean
+        in: query
+        name: is_new
+      - schema:
+          type: boolean
+        in: query
+        name: is_early
+      - schema:
+          type: boolean
+        in: query
+        name: is_github
+      - schema:
+          type: boolean
+        in: query
+        name: is_draft
   /v1/scans/config/severity:
     get:
       summary: Get custom severity mappings
@@ -3885,11 +9102,654 @@ paths:
         description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
       requestBody:
         $ref: '#/components/requestBodies/AddCustomSeverityMappingRequest'
+  /v1/leaks/stats/domain:
+    get:
+      summary: Get leak statistics for a domain
+      tags:
+      - leaks
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  leak_devices_count:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/DevicesCount'
+                  leak_customers_count:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/CustomersCount'
+                  leak_user_count:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/UsersCount'
+                  leak_employees_count:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/EmployeesCount'
+                  combolist_exposure:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/CombolistExposureCount'
+                  leak_country_stats:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/LeakCountryStats'
+                  top_used_urls_by_customers:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/UsedUrlsCount'
+                  top_used_urls_by_employees:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/UsedUrlsCount'
+                  top_used_urls_by_user:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/UsedUrlsCount'
+                  leak_customers_timeline:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/LeaksTimeline'
+                  leak_user_timeline:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/LeaksTimeline'
+                  leak_employees_timeline:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/LeaksTimeline'
+                  customers_sample_data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/LeaksUsersSampleData'
+                  employees_sample_data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/LeaksUsersSampleData'
+                  user_sample_data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/LeaksUsersSampleData'
+        '400':
+          $ref: '#/components/responses/MessageResponse'
+        '401':
+          $ref: '#/components/responses/MessageResponse'
+        '403':
+          $ref: '#/components/responses/MessageResponse'
+        '404':
+          $ref: '#/components/responses/MessageResponse'
+        '500':
+          $ref: '#/components/responses/MessageResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v1-leaks-stats-domain
+      description: get leaks stats for a domain
+      parameters:
+      - schema:
+          type: string
+        in: query
+        name: domain
+      - schema:
+          type: boolean
+        in: query
+        name: unmask_email
+  /v1/leaks/stats/email:
+    get:
+      summary: Get leak statistics for an email address
+      tags:
+      - leaks
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  leak_devices_count:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/DevicesCount'
+                  leak_customers_count:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/CustomersCount'
+                  leak_user_count:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/UsersCount'
+                  leak_employees_count:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/EmployeesCount'
+                  combolist_exposure:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/CombolistExposureCount'
+                  leak_country_stats:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/LeakCountryStats'
+                  top_used_urls_by_customers:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/UsedUrlsCount'
+                  top_used_urls_by_employees:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/UsedUrlsCount'
+                  top_used_urls_by_user:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/UsedUrlsCount'
+                  leak_customers_timeline:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/LeaksTimeline'
+                  leak_user_timeline:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/LeaksTimeline'
+                  leak_employees_timeline:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/LeaksTimeline'
+                  customers_sample_data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/LeaksUsersSampleData'
+                  employees_sample_data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/LeaksUsersSampleData'
+                  user_sample_data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/LeaksUsersSampleData'
+        '400':
+          $ref: '#/components/responses/MessageResponse'
+        '401':
+          $ref: '#/components/responses/MessageResponse'
+        '403':
+          $ref: '#/components/responses/MessageResponse'
+        '404':
+          $ref: '#/components/responses/MessageResponse'
+        '500':
+          $ref: '#/components/responses/MessageResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v1-leaks-stats-email
+      description: get leaks stats for an email
+      parameters:
+      - schema:
+          type: string
+        in: query
+        name: email
+        description: Email to get stats for
+      - schema:
+          type: boolean
+        in: query
+        name: unmask_email
+  /v1/leaks:
+    get:
+      summary: Get all leaked credentials
+      description: Returns all leaks (personal, employee, customer) with optional type filtering. Replaces the need for separate endpoint calls.
+      tags: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        url:
+                          type: string
+                        username:
+                          type: string
+                        password:
+                          type: string
+                        device_ip:
+                          type: string
+                        hostname:
+                          type: string
+                        os:
+                          type: string
+                        malware_path:
+                          type: string
+                        country:
+                          type: string
+                        log_date:
+                          type: string
+                        hardware_id:
+                          type: string
+                        domain:
+                          type: string
+                        email_domain:
+                          type: string
+                        url_domain:
+                          type: string
+                        fetched_at:
+                          type: string
+                        status:
+                          type: string
+                        user_type:
+                          type: string
+                          description: Classification of leak type (personal, employee, customer, external_vendor_leaks, organization_leaks)
+                  total_leaks:
+                    type: number
+                  total_pages:
+                    type: number
+                  total_count:
+                    type: number
+                  summary:
+                    type: object
+                    properties:
+                      total_leaks:
+                        type: number
+                      personal_leaks:
+                        type: number
+                      employee_leaks:
+                        type: number
+                      customer_leaks:
+                        type: number
+                      external_vendor_leaks:
+                        type: number
+                        description: Employee leaks on external vendor systems (login URL domain != email domain)
+                      organization_leaks:
+                        type: number
+                        description: Employee leaks on organization systems (login URL domain == email domain)
+                  group_summary:
+                    type: array
+                    description: Group summary data when group_by parameter is used
+                    items:
+                      type: object
+                      additionalProperties: true
+                      description: Dynamic group summary with field name as key and count
+        '400':
+          $ref: '#/components/responses/MessageResponse'
+        '401':
+          $ref: '#/components/responses/MessageResponse'
+        '403':
+          $ref: '#/components/responses/MessageResponse'
+        '404':
+          $ref: '#/components/responses/MessageResponse'
+        '500':
+          $ref: '#/components/responses/MessageResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v1-leaks
+      parameters:
+      - schema:
+          type: string
+          enum:
+          - all
+          - personal
+          - employee
+          - customer
+          - external_vendor_leaks
+          - organization_leaks
+          default: all
+        in: query
+        name: type
+        description: Filter by specific leak type (single value only)
+      - schema:
+          type: string
+        in: query
+        name: domain
+        description: Filter leaks by specific domain (applies to employee/customer leaks)
+      - schema:
+          type: string
+        in: query
+        name: email
+        description: Filter leaks by specific email (can be personal, employee, or customer email from user's authorized results)
+      - schema:
+          type: string
+        in: query
+        name: search
+        description: Search query to filter results across all fields
+      - schema:
+          type: number
+        in: query
+        name: limit
+        description: Number of results per page for pagination
+      - schema:
+          type: number
+        in: query
+        name: page_number
+        description: Page number for pagination (starts from 1)
+      - schema:
+          type: string
+          format: date
+        in: query
+        name: start_date
+        description: time filter start date
+      - schema:
+          type: string
+          default: all_time
+          enum:
+          - all_time
+          - current_month
+          - last_month
+          - last_3_months
+          - last_6_months
+          - last_12_months
+        in: query
+        name: time_range
+      - schema:
+          type: string
+          format: date
+        in: query
+        name: end_date
+        description: time filter end date
+      - schema:
+          type: string
+          enum:
+          - url
+          - username
+          - log_date
+          - country
+          - device_ip
+          - host_username
+          - hostname
+          - os
+          - hardware_id
+          - malware_path
+        in: query
+        name: sort_by
+        description: supported sort fields
+      - schema:
+          type: string
+          enum:
+          - asc
+          - desc
+        in: query
+        name: sort_order
+        description: supported sort order (asc or desc)
+      - schema:
+          type: string
+          enum:
+          - fixed
+          - open
+        in: query
+        name: status
+        description: supported status (fixed or open)
+      - schema:
+          type: string
+          enum:
+          - url
+          - country
+          - device_ip
+          - hostname
+          - email
+          - hardware_id
+        in: query
+        name: group_by
+        description: Group results by field - returns group summaries when used without field-specific filtering
+      - schema:
+          type: string
+        in: query
+        name: url
+        description: Filter by specific URL (used with group_by for drill-down)
+      - schema:
+          type: string
+        in: query
+        name: country
+        description: Filter by specific country (used with group_by for drill-down)
+      - schema:
+          type: string
+        in: query
+        name: device_ip
+        description: Filter by specific device IP (used with group_by for drill-down)
+      - schema:
+          type: string
+        in: query
+        name: hostname
+        description: Filter by specific hostname (used with group_by for drill-down)
+      - schema:
+          type: string
+        in: query
+        name: hardware_id
+        description: Filter by specific hardware ID (used with group_by for drill-down)
+  /v1/leaks/export:
+    post:
+      summary: Export leaked credentials
+      description: Export leaked credentials with same filtering options as GET /v1/leaks
+      tags:
+      - export
+      responses:
+        '200':
+          description: Export data returned successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        url:
+                          type: string
+                        username:
+                          type: string
+                        password:
+                          type: string
+                        device_ip:
+                          type: string
+                        hostname:
+                          type: string
+                        os:
+                          type: string
+                        malware_path:
+                          type: string
+                        country:
+                          type: string
+                        log_date:
+                          type: string
+                        hardware_id:
+                          type: string
+                        domain:
+                          type: string
+                        email_domain:
+                          type: string
+                        url_domain:
+                          type: string
+                        fetched_at:
+                          type: string
+                        status:
+                          type: string
+                        user_type:
+                          type: string
+                          description: Classification of leak type (personal, employee, customer, external_vendor_leaks, organization_leaks)
+                  total_leaks:
+                    type: number
+                  total_pages:
+                    type: number
+                  total_count:
+                    type: number
+                  summary:
+                    type: object
+                    properties:
+                      total_leaks:
+                        type: number
+                      personal_leaks:
+                        type: number
+                      employee_leaks:
+                        type: number
+                      customer_leaks:
+                        type: number
+                      external_vendor_leaks:
+                        type: number
+                        description: Employee leaks on external vendor systems (login URL domain != email domain)
+                      organization_leaks:
+                        type: number
+                        description: Employee leaks on organization systems (login URL domain == email domain)
+                  group_summary:
+                    type: array
+                    description: Group summary data when group_by parameter is used
+                    items:
+                      type: object
+                      additionalProperties: true
+                      description: Dynamic group summary with field name as key and count
+            text/csv:
+              schema:
+                type: string
+                description: CSV formatted export data
+        '400':
+          $ref: '#/components/responses/MessageResponse'
+        '401':
+          $ref: '#/components/responses/MessageResponse'
+        '403':
+          $ref: '#/components/responses/MessageResponse'
+        '404':
+          $ref: '#/components/responses/MessageResponse'
+        '500':
+          $ref: '#/components/responses/MessageResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: post-v1-leaks-export
+      parameters:
+      - schema:
+          type: string
+          enum:
+          - json
+          - csv
+          default: json
+        in: query
+        name: format
+        description: Export format (json or csv)
+      - schema:
+          type: string
+        in: header
+        name: X-Team-Id
+        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                type:
+                  type: string
+                  enum:
+                  - all
+                  - personal
+                  - employee
+                  - customer
+                  - external_vendor_leaks
+                  - organization_leaks
+                  default: all
+                  description: Filter by specific leak type (single value only)
+                domain:
+                  type: string
+                  description: Filter leaks by specific domain (applies to employee/customer leaks)
+                email:
+                  type: string
+                  description: Filter leaks by specific email (can be personal, employee, or customer email from user's authorized results)
+                search:
+                  type: string
+                  description: Search query to filter results across all fields
+                limit:
+                  type: number
+                  description: Number of results per page for pagination
+                page_number:
+                  type: number
+                  description: Page number for pagination (starts from 1)
+                start_date:
+                  type: string
+                  format: date
+                  description: time filter start date
+                time_range:
+                  type: string
+                  enum:
+                  - all_time
+                  - current_month
+                  - last_month
+                  - last_3_months
+                  - last_6_months
+                  - last_12_months
+                  default: all_time
+                end_date:
+                  type: string
+                  format: date
+                  description: time filter end date
+                sort_by:
+                  type: string
+                  enum:
+                  - url
+                  - username
+                  - log_date
+                  - country
+                  - device_ip
+                  - host_username
+                  - hostname
+                  - os
+                  - hardware_id
+                  - malware_path
+                  description: supported sort fields
+                sort_order:
+                  type: string
+                  enum:
+                  - asc
+                  - desc
+                  description: supported sort order (asc or desc)
+                status:
+                  type: string
+                  enum:
+                  - fixed
+                  - open
+                  description: supported status (fixed or open)
+                group_by:
+                  type: string
+                  enum:
+                  - url
+                  - country
+                  - device_ip
+                  - hostname
+                  - email
+                  - hardware_id
+                  description: Group results by field - returns group summaries when used without field-specific filtering
+                url:
+                  type: string
+                  description: Filter by specific URL (used with group_by for drill-down)
+                country:
+                  type: string
+                  description: Filter by specific country (used with group_by for drill-down)
+                device_ip:
+                  type: string
+                  description: Filter by specific device IP (used with group_by for drill-down)
+                hostname:
+                  type: string
+                  description: Filter by specific hostname (used with group_by for drill-down)
+                hardware_id:
+                  type: string
+                  description: Filter by specific hardware ID (used with group_by for drill-down)
   /v1/leaks/domain:
     get:
-      summary: Get Domain Leaks
+      summary: Get employee/corporate leaks for verified domains (DEPRECATED)
+      deprecated: true
+      description: '**DEPRECATED:** This endpoint is deprecated in favor of the consolidated `/v1/leaks` endpoint.
+
+        '
       tags:
-        - leaks
+      - deprecated
       responses:
         '200':
           description: OK
@@ -3976,7 +9836,6 @@ paths:
           - host_username
           - hostname
           - os
-          - source
           - hardware_id
           - malware_path
         in: query
@@ -3994,15 +9853,19 @@ paths:
           type: string
           enum:
           - fixed
-          - unfixed
+          - open
         in: query
         name: status
-        description: supported status (fixed or unfixed)
+        description: supported status (fixed or open)
   /v1/leaks/email:
     get:
-      summary: Get Email Leaks
+      summary: Get personal email leaks for authenticated user (DEPRECATED)
+      deprecated: true
+      description: '**DEPRECATED:** This endpoint is deprecated in favor of the consolidated `/v1/leaks` endpoint.
+
+        '
       tags:
-        - leaks
+      - deprecated
       responses:
         '200':
           description: OK
@@ -4085,7 +9948,6 @@ paths:
           - host_username
           - hostname
           - os
-          - source
           - hardware_id
           - malware_path
         in: query
@@ -4103,15 +9965,19 @@ paths:
           type: string
           enum:
           - fixed
-          - unfixed
+          - open
         in: query
         name: status
-        description: supported status (fixed or unfixed)
+        description: supported status (fixed or open)
   /v1/leaks/domain/customers:
     get:
-      summary: Get Customer Leaks
+      summary: Get customer leaks for verified domains (DEPRECATED)
+      deprecated: true
+      description: '**DEPRECATED:** This endpoint is deprecated in favor of the consolidated `/v1/leaks` endpoint.
+
+        '
       tags:
-        - leaks
+      - deprecated
       responses:
         '200':
           description: OK
@@ -4194,7 +10060,6 @@ paths:
           - host_username
           - hostname
           - os
-          - source
           - hardware_id
           - malware_path
         in: query
@@ -4212,10 +10077,10 @@ paths:
           type: string
           enum:
           - fixed
-          - unfixed
+          - open
         in: query
         name: status
-        description: supported status (fixed or unfixed)
+        description: supported status (fixed or open)
   /v1/asset/enumerate/{enumerate_id}/history:
     parameters:
     - schema:
@@ -4268,8 +10133,7 @@ paths:
           type: integer
         in: query
         name: offset
-        description: The number of items to skip before starting to collect the result
-          set
+        description: The number of items to skip before starting to collect the result set
       - schema:
           type: integer
         in: query
@@ -4443,52 +10307,51 @@ paths:
       tags: []
       responses:
         '200':
-          description: OK
           content:
             application/json:
               schema:
-                type: array
                 items:
-                  type: object
-                  required:
-                  - can_sort
-                  - data_type
-                  - description
-                  - examples
-                  - facet_possible
-                  - field
-                  - search_analyzer
-                  - enum_values
                   properties:
                     can_sort:
-                      type: boolean
                       description: Indicates if sorting is possible by this field.
-                    data_type:
-                      type: string
-                      description: The data type of the filter field (e.g., string,
-                        number, datetime).
-                    description:
-                      type: string
-                      description: A human-readable description of the filter field.
-                    examples:
-                      type: array
-                      description: Example usage of the filter.
-                      items:
-                        type: string
-                    facet_possible:
                       type: boolean
-                      description: Indicates if faceting is possible for this field.
-                    field:
+                    data_type:
+                      description: The data type of the filter field (e.g., string, number, datetime).
                       type: string
-                      description: The name of the filter field.
-                    search_analyzer:
+                    description:
+                      description: A human-readable description of the filter field.
                       type: string
-                      description: The search analyzer used for this field.
                     enum_values:
                       description: The possible values for this field.
                       items:
                         type: string
                       type: array
+                    examples:
+                      description: Example usage of the filter.
+                      items:
+                        type: string
+                      type: array
+                    facet_possible:
+                      description: Indicates if faceting is possible for this field.
+                      type: boolean
+                    field:
+                      description: The name of the filter field.
+                      type: string
+                    search_analyzer:
+                      description: The search analyzer used for this field.
+                      type: string
+                  required:
+                  - field
+                  - data_type
+                  - description
+                  - facet_possible
+                  - can_sort
+                  - examples
+                  - search_analyzer
+                  - enum_values
+                  type: object
+                type: array
+          description: OK
         '400':
           $ref: '#/components/responses/ErrorResponse'
         '404':
@@ -4500,108 +10363,16 @@ paths:
       operationId: get-v2-vulnerability-filters
       description: Get all filters for vulnerabilities
     parameters: []
-  /v1/asset/enumerate/group/{group_id}:
+  /v1/scans/{scan_id}/error_stats:
     parameters:
     - schema:
         type: string
-      name: group_id
+      name: scan_id
       in: path
       required: true
-    delete:
-      summary: Delete an asset group
-      tags:
-      - enumerations
-      responses:
-        '200':
-          $ref: '#/components/responses/MessageResponse'
-        '400':
-          $ref: '#/components/responses/ErrorResponse'
-        '401':
-          $ref: '#/components/responses/ErrorResponse'
-        '403':
-          $ref: '#/components/responses/ErrorResponse'
-        '500':
-          $ref: '#/components/responses/ErrorResponse'
-        default:
-          $ref: '#/components/responses/ErrorResponse'
-      operationId: delete-v1-asset-enumerate-group
-      parameters:
-      - schema:
-          type: string
-        in: header
-        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
-        name: X-Team-Id
-      security:
-      - X-API-Key: []
-      description: Delete an asset group by id
-    patch:
-      summary: Update an asset group
-      tags:
-      - enumerations
-      responses:
-        '200':
-          $ref: '#/components/responses/MessageResponse'
-        '400':
-          $ref: '#/components/responses/ErrorResponse'
-        '401':
-          $ref: '#/components/responses/ErrorResponse'
-        '403':
-          $ref: '#/components/responses/ErrorResponse'
-        '500':
-          $ref: '#/components/responses/ErrorResponse'
-        default:
-          $ref: '#/components/responses/ErrorResponse'
-      requestBody:
-        $ref: '#/components/requestBodies/UpdateAssetGroupRequest'
-      operationId: patch-v1-asset-enumerate-group
-      parameters:
-      - schema:
-          type: string
-          enum:
-          - append
-          - replace
-          default: append
-        in: query
-        name: update_type
-        description: Append vs Replace update_type. Default is append
-      - schema:
-          type: string
-        in: header
-        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
-        name: X-Team-Id
-      security:
-      - X-API-Key: []
-      description: Update an asset group by customising the filters
-  /v1/user/team:
     get:
-      summary: Get Team
-      operationId: get-v1-user-team
-      tags:
-      - internal
-      responses:
-        '200':
-          $ref: '#/components/responses/GetTeamResponse'
-        '401':
-          $ref: '#/components/responses/MessageResponse'
-        '403':
-          $ref: '#/components/responses/MessageResponse'
-        '500':
-          $ref: '#/components/responses/MessageResponse'
-        default:
-          $ref: '#/components/responses/ErrorResponse'
-      security:
-      - X-API-Key: []
-      description: Get a team metadata
-      parameters:
-      - schema:
-          type: string
-        in: header
-        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
-        name: X-Team-Id
-    post:
-      summary: Create Workspace
-      tags:
-      - internal
+      summary: Get error statistics of given scan id
+      tags: []
       responses:
         '200':
           description: OK
@@ -4610,41 +10381,8 @@ paths:
               schema:
                 type: object
                 properties:
-                  message:
-                    type: string
-                  team_id:
-                    type: string
-                required:
-                - message
-                - team_id
-        '400':
-          $ref: '#/components/responses/MessageResponse'
-        '401':
-          $ref: '#/components/responses/MessageResponse'
-        '500':
-          $ref: '#/components/responses/MessageResponse'
-        default:
-          $ref: '#/components/responses/ErrorResponse'
-      operationId: post-v1-user-team
-      requestBody:
-        $ref: '#/components/requestBodies/CreateTeamRequest'
-      security:
-      - X-API-Key: []
-      description: 'Create a new team '
-      parameters:
-      - schema:
-          type: string
-        in: header
-        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
-        name: X-Team-Id
-    patch:
-      summary: Update Team
-      operationId: patch-v1-user-team
-      tags:
-      - internal
-      responses:
-        '200':
-          $ref: '#/components/responses/UpdateTeamResponse'
+                  data:
+                    $ref: '#/components/schemas/StatisticsResponse'
         '400':
           $ref: '#/components/responses/ErrorResponse'
         '401':
@@ -4655,52 +10393,706 @@ paths:
           $ref: '#/components/responses/ErrorResponse'
         default:
           $ref: '#/components/responses/ErrorResponse'
-      security:
-      - X-API-Key: []
-      requestBody:
-        $ref: '#/components/requestBodies/CreateTeamRequest'
-      description: Update a existing team
+      operationId: get-scans-id-error-stats
+  /v1/template/leaderboard/{name}:
+    parameters:
+    - schema:
+        type: string
+      name: name
+      in: path
+      required: true
+    get:
+      summary: Get Leaderboard ID Details
+      tags: []
+      responses:
+        '200':
+          description: Shared Response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                    description: The number of results
+                  facets:
+                    type: object
+                    description: The search facets
+                    additionalProperties:
+                      $ref: '#/components/schemas/Facets'
+                  results:
+                    type: array
+                    description: The search results
+                    items:
+                      $ref: '#/components/schemas/TemplateData'
+                  total:
+                    type: integer
+                    description: The total number of results
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '404':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v1-template-leaderboard-id
+      description: Get public templates leaderboard ID details
       parameters:
       - schema:
-          type: string
-        in: header
-        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
-        name: X-Team-Id
-    delete:
-      summary: Delete Team
+          type: array
+          items:
+            type: string
+        in: query
+        name: fields
+        description: List of fields to return(comma separated)
+      - schema:
+          type: integer
+        in: query
+        name: limit
+        description: The numbers of items to return
+      - schema:
+          type: integer
+        in: query
+        name: offset
+        description: The numbers of items to skip
+  /v1/leaks/status:
+    post:
+      summary: Update leak status
       tags:
-      - internal
+        - leaks
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                  message:
+                    type: string
+                  leak_id:
+                    type: string
+                  new_status:
+                    $ref: '#/components/schemas/LeaksEntityStatus'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '403':
+          description: Access denied - Insufficient permissions to update this leak status
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: 'Access denied: you don''t have access to this leak'
+        '404':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: post-v1-leaks-status
       requestBody:
         content:
           application/json:
             schema:
               type: object
               properties:
-                team_id:
+                leakid:
                   type: string
+                leakids:
+                  type: array
+                  items:
+                    type: string
+                status:
+                  $ref: '#/components/schemas/LeaksEntityStatus'
+  /v1/leaks/info:
+    post:
+      summary: Get leak information by ID
+      description: Retrieve detailed leak information by leak ID with optional password and email unmasking
+      tags:
+      - leaks
+      operationId: post-v1-leaks-info
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
               required:
-              - team_id
+              - leakid
+              properties:
+                leakid:
+                  type: string
+                  description: 32-character MD5 hash identifying the leak
+                  pattern: ^[a-fA-F0-9]{32}$
+                  example: b3652f2555841f7652badd9804859f4e
       responses:
         '200':
-          description: OK
+          description: Leak information retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      url:
+                        type: string
+                      username:
+                        type: string
+                      password:
+                        type: string
+                      device_ip:
+                        type: string
+                      hostname:
+                        type: string
+                      os:
+                        type: string
+                      malware_path:
+                        type: string
+                      country:
+                        type: string
+                      log_date:
+                        type: string
+                      hardware_id:
+                        type: string
+                      domain:
+                        type: string
+                        description: Domain this leak is associated with - used for filtering
+                      email_domain:
+                        type: string
+                        description: Domain extracted from email addresses
+                      fetched_at:
+                        type: string
+                      status:
+                        type: string
         '400':
+          description: Bad request - Invalid leak ID format or missing leak ID
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: Invalid leak ID format
+        '401':
           $ref: '#/components/responses/MessageResponse'
         '403':
-          $ref: '#/components/responses/MessageResponse'
+          description: Access denied - Insufficient permissions to access this leak
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: 'Access denied: you don''t have access to this leak'
+        '404':
+          description: Leak not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: Leak not found
         '500':
           $ref: '#/components/responses/MessageResponse'
         default:
           $ref: '#/components/responses/ErrorResponse'
-      operationId: delete-v1-user-team
-      security:
-      - X-API-Key: []
-      description: Delete team (require 0 members)
+  /v2/vulnerability/product/search:
+    get:
+      summary: Search Products
+      tags: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                  facets:
+                    type: object
+                    additionalProperties:
+                      $ref: '#/components/schemas/Facets'
+                  results:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Product'
+                  total:
+                    type: integer
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '403':
+          $ref: '#/components/responses/ErrorResponse'
+        '404':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v2-product-search
+      description: Search products with filtering and faceting capabilities
+      parameters:
+      - schema:
+          type: integer
+        in: query
+        name: limit
+        description: The numbers of items to return
+      - schema:
+          type: integer
+        in: query
+        name: offset
+        description: The numbers of items to skip
+      - schema:
+          type: string
+        in: query
+        name: sort_asc
+        description: Sort results in ascending order (CSV field names)
+      - schema:
+          type: string
+        in: query
+        name: sort_desc
+        description: Sort results in descending order (CSV field names)
+      - schema:
+          items:
+            type: string
+          type: array
+        in: query
+        name: fields
+        description: List of fields to return(comma separated)
+      - schema:
+          items:
+            type: string
+          type: array
+        in: query
+        name: term_facets
+        description: List of fields to return(comma separated)
+      - schema:
+          items:
+            type: string
+          type: array
+        in: query
+        name: range_facets
+        description: List of fields to return(comma separated)
+      - schema:
+          type: string
+        in: query
+        name: q
+        description: query
+      - schema:
+          type: boolean
+        in: query
+        name: highlight
+        description: Whether to highlight the search results
+      - schema:
+          type: integer
+        in: query
+        name: facet_size
+        description: Number of facets to return
+    parameters: []
+  /v2/vulnerability/product/{id}:
+    parameters:
+    - schema:
+        type: string
+      name: id
+      in: path
+      required: true
+    get:
+      summary: Get Product by ID
+      tags: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/Product'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '404':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-product-by-id
+      description: Get Product by ID
       parameters:
       - schema:
           type: string
+        in: query
+        name: fields
+        description: 'product data fields '
+  /v2/vulnerability/product/{id}/vulns:
+    parameters:
+    - schema:
+        type: string
+      name: id
+      in: path
+      required: true
+    get:
+      summary: Get Vulnerabilities for Product
+      tags: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                  facets:
+                    type: object
+                    additionalProperties:
+                      $ref: '#/components/schemas/Facets'
+                  results:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Vulnerability'
+                  total:
+                    type: integer
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '404':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-product-vulns
+      description: Get vulnerabilities for a specific product
+      parameters:
+      - schema:
+          type: integer
+        in: query
+        name: limit
+        description: The numbers of items to return
+      - schema:
+          type: integer
+        in: query
+        name: offset
+        description: The numbers of items to skip
+      - schema:
+          type: string
+        in: query
+        name: sort_asc
+        description: Sort results in ascending order (CSV field names)
+      - schema:
+          type: string
+        in: query
+        name: sort_desc
+        description: Sort results in descending order (CSV field names)
+      - schema:
+          items:
+            type: string
+          type: array
+        in: query
+        name: fields
+        description: List of fields to return(comma separated)
+      - schema:
+          items:
+            type: string
+          type: array
+        in: query
+        name: term_facets
+        description: List of fields to return(comma separated)
+      - schema:
+          items:
+            type: string
+          type: array
+        in: query
+        name: range_facets
+        description: List of fields to return(comma separated)
+      - schema:
+          type: string
+        in: query
+        name: q
+        description: query
+      - schema:
+          type: boolean
+        in: query
+        name: highlight
+        description: Whether to highlight the search results
+      - schema:
+          type: integer
+        in: query
+        name: facet_size
+        description: Number of facets to return
+  /v2/vulnerability/product/{id}/timeline:
+    parameters:
+    - schema:
+        type: string
+      name: id
+      in: path
+      required: true
+    get:
+      summary: Get Vulnerability Timeline for Product
+      tags: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                  facets:
+                    type: object
+                    additionalProperties:
+                      $ref: '#/components/schemas/Facets'
+                  results:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Vulnerability'
+                  total:
+                    type: integer
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '404':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-product-timeline
+      description: Get vulnerability timeline for a specific product (sorted by cve_created_at descending)
+      parameters:
+      - schema:
+          type: integer
+        in: query
+        name: limit
+        description: The numbers of items to return
+      - schema:
+          type: integer
+        in: query
+        name: offset
+        description: The numbers of items to skip
+      - schema:
+          type: string
+        in: query
+        name: sort_asc
+        description: Sort results in ascending order (CSV field names)
+      - schema:
+          type: string
+        in: query
+        name: sort_desc
+        description: Sort results in descending order (CSV field names)
+      - schema:
+          items:
+            type: string
+          type: array
+        in: query
+        name: fields
+        description: List of fields to return(comma separated)
+      - schema:
+          items:
+            type: string
+          type: array
+        in: query
+        name: term_facets
+        description: List of fields to return(comma separated)
+      - schema:
+          items:
+            type: string
+          type: array
+        in: query
+        name: range_facets
+        description: List of fields to return(comma separated)
+      - schema:
+          type: string
+        in: query
+        name: q
+        description: query
+      - schema:
+          type: boolean
+        in: query
+        name: highlight
+        description: Whether to highlight the search results
+      - schema:
+          type: integer
+        in: query
+        name: facet_size
+        description: Number of facets to return
+  /v2/vulnerability/product/filters:
+    get:
+      summary: Get All Filters for Products
+      tags: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  properties:
+                    can_sort:
+                      description: Indicates if sorting is possible by this field.
+                      type: boolean
+                    data_type:
+                      description: The data type of the filter field (e.g., string, number, datetime).
+                      type: string
+                    description:
+                      description: A human-readable description of the filter field.
+                      type: string
+                    enum_values:
+                      description: The possible values for this field.
+                      items:
+                        type: string
+                      type: array
+                    examples:
+                      description: Example usage of the filter.
+                      items:
+                        type: string
+                      type: array
+                    facet_possible:
+                      description: Indicates if faceting is possible for this field.
+                      type: boolean
+                    field:
+                      description: The name of the filter field.
+                      type: string
+                    search_analyzer:
+                      description: The search analyzer used for this field.
+                      type: string
+                  required:
+                  - field
+                  - data_type
+                  - description
+                  - facet_possible
+                  - can_sort
+                  - examples
+                  - search_analyzer
+                  - enum_values
+                  type: object
+                type: array
+          description: OK
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '404':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-v2-product-filters
+      description: Get all filters for products
+    parameters: []
+  /v1/report/export:
+    post:
+      summary: Export report
+      tags:
+      - export
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  export_id:
+                    type: string
+                  export_url:
+                    type: string
+                  message:
+                    type: string
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '403':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: post-v1-report-export
+      parameters:
+      - schema:
+          type: string
+          enum:
+          - executive_summary
+          - security_posture
+        in: query
+        name: report_type
+      - schema:
+          type: string
+          default: all_time
+          enum:
+          - all_time
+          - last_month
+          - last_3_months
+          - last_6_months
+          - last_12_months
+        in: query
+        name: time
+      - schema:
+          type: string
+          format: date
+          description: Filter by start date
+        in: query
+        name: start_date
+      - schema:
+          type: string
+          format: date
+          description: Filter by end date
+        in: query
+        name: end_date
+      - schema:
+          type: string
         in: header
-        description: 'Retrieve the Team ID from: https://cloud.projectdiscovery.io/settings/team'
         name: X-Team-Id
+  /v1/admin/report/export/{export_id}/status:
+    parameters:
+    - schema:
+        type: string
+      name: export_id
+      in: path
+      required: true
+  /v1/admin/report/{report_type}:
+    parameters:
+    - schema:
+        type: string
+        enum:
+        - executive_summary
+        - security_posture
+      name: report_type
+      in: path
+      required: true
 components:
   schemas:
     AssetCategory:
@@ -4922,6 +11314,16 @@ components:
       - count
     VulnerabilityResults:
       type: object
+      required:
+      - matcher_status
+      - vuln_id
+      - target
+      - created_at
+      - scan_id
+      - event
+      - template_id
+      - result_type
+      - vuln_hash
       properties:
         matcher_status:
           type: boolean
@@ -4964,16 +11366,16 @@ components:
         asset_metadata:
           type: object
           $ref: '#/components/schemas/EnumerationContent'
-      required:
-      - matcher_status
-      - vuln_id
-      - target
-      - created_at
-      - scan_id
-      - event
-      - template_id
-      - result_type
-      - vuln_hash
+        remediation:
+          type: string
+        description:
+          type: string
+        impact:
+          type: string
+        reference:
+          type: array
+          items:
+            type: string
     VulnerabilityChangelogs:
       title: VulnerabilityChangelogs
       type: object
@@ -5077,8 +11479,7 @@ components:
           type: integer
         custom_weekdays:
           type: array
-          description: 'Array of integer denoting the weekdays on which the scan is
-            supposed to run.
+          description: 'Array of integer denoting the weekdays on which the scan is supposed to run.
 
             0-6 denoting Sunday-Saturday.'
           items:
@@ -5507,6 +11908,16 @@ components:
         asset_metadata:
           type: object
           $ref: '#/components/schemas/EnumerationContent'
+        remediation:
+          type: string
+        impact:
+          type: string
+        description:
+          type: string
+        reference:
+          type: array
+          items:
+            type: string
     templateListItem:
       title: templateListItem
       type: object
@@ -6063,8 +12474,7 @@ components:
           type: integer
         custom_weekdays:
           type: array
-          description: 'Array of integer denoting the weekdays on which the scan is
-            supposed to run.
+          description: 'Array of integer denoting the weekdays on which the scan is supposed to run.
 
             0-6 denoting Sunday-Saturday.'
           items:
@@ -6537,6 +12947,12 @@ components:
           type: string
         exclude_type:
           $ref: '#/components/schemas/ExcludeConfigRequestType'
+        scan_id:
+          type: string
+          description: Optional scan ID if this rule is scoped to a specific scan
+        enumeration_id:
+          type: string
+          description: Optional enumeration ID if this rule is scoped to a specific enumeration
         created_at:
           type: string
           format: date-time
@@ -6687,8 +13103,7 @@ components:
           description: The product of the template
         classification:
           $ref: '#/components/schemas/Classification'
-          description: Classification of template including additional metadata like
-            cve-id, cwe-id etc
+          description: Classification of template including additional metadata like cve-id, cwe-id etc
         metadata:
           type: object
         digest:
@@ -6704,8 +13119,7 @@ components:
           description: The time when template was updated
         release_tag:
           type: string
-          description: The release tag of the template (contains tag when the file
-            was first released)
+          description: The release tag of the template (contains tag when the file was first released)
         is_early:
           type: boolean
           description: True if template is in early access
@@ -6737,11 +13151,8 @@ components:
           type: boolean
         is_new:
           type: boolean
-        is_pdresearch:
-          type: boolean
         is_pdteam:
-          type: boolean
-        is_pdtemplate:
+          description: Is the template from pdteam
           type: boolean
         remediation:
           type: string
@@ -6758,8 +13169,7 @@ components:
             description: Type of share (unlisted, users, organization)
           users_email:
             type: array
-            description: List of email addresses or user IDs to share with (required
-              if share_type is set to 'users')
+            description: List of email addresses or user IDs to share with (required if share_type is set to 'users')
             items:
               type: string
           organizations:
@@ -6767,8 +13177,7 @@ components:
             items:
               type: string
     Classification:
-      description: Classification of template including additional metadata like cve-id,
-        cwe-id etc
+      description: Classification of template including additional metadata like cve-id, cwe-id etc
       type: object
       properties:
         cve-id:
@@ -7666,7 +14075,7 @@ components:
       title: UsedUrlsCount
       type: object
       properties:
-        Occurrences:
+        count:
           type: number
         url:
           type: string
@@ -7724,6 +14133,12 @@ components:
           type: string
         status:
           $ref: '#/components/schemas/LeaksEntityStatus'
+        domain:
+          type: string
+          description: Domain this leak is associated with - used for filtering
+        email_domain:
+          type: string
+          description: Domain extracted from email addresses
     EnumerationHistoryDataResponse:
       title: EnumerationHistoryDataResponse
       type: object
@@ -7775,33 +14190,157 @@ components:
           type: integer
         total:
           type: integer
+    Product:
+      type: object
+      required:
+      - doc_id
+      - vuln_count
+      - kev_count
+      - vulns_with_poc
+      - product
+      - vendor
+      properties:
+        category:
+          description: Product category
+          type: string
+        cpe:
+          description: List of CPEs for this product
+          type: array
+          items:
+            type: string
+        deployment_model:
+          description: Product deployment model
+          type: string
+        doc_id:
+          description: Unique document ID in the form vendor:product
+          type: string
+        exposure:
+          $ref: '#/components/schemas/ExposureStats'
+        first_cve_created_at:
+          description: Date when the earliest CVE was processed for this product
+          type: string
+          format: date-time
+        industry:
+          description: Product industry
+          type: string
+        kev_count:
+          description: Number of KEV vulnerabilities for this product
+          type: integer
+        last_cve_created_at:
+          description: Date when the most recent CVE was processed for this product
+          type: string
+          format: date-time
+        product:
+          description: Product name
+          type: string
+        project_repos:
+          description: List of repository info for this product
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+        projects:
+          description: List of project URLs for this product
+          type: array
+          items:
+            type: string
+        score:
+          description: Impact score based on available parameters mainly used for sorting
+          type: number
+        summary:
+          description: Product summary
+          type: string
+        tech_domain:
+          description: Product tech domain
+          type: string
+        vendor:
+          description: Vendor name
+          type: string
+        vulnerability_count:
+          description: Total number of vulnerabilities for this product
+          type: integer
+        vulnerability_max_cvss:
+          description: Maximum CVSS score among vulnerabilities
+          type: number
+          format: double
+        vulnerability_mean_cvss:
+          description: Mean CVSS score among vulnerabilities
+          type: number
+          format: double
+        vulnerability_poc_count:
+          description: Number of vulnerabilities with PoC for this product
+          type: integer
+        vulnerability_stat_counts:
+          description: Vulnerability statistics by type
+          type: object
+          additionalProperties:
+            type: integer
+        severities:
+          description: Map of severity -> count for vulnerabilities
+          type: object
+          additionalProperties:
+            type: integer
+        vuln_count:
+          description: Total number of vulnerabilities for this product
+          type: integer
+        vuln_impact_breakdown:
+          description: Map of vulnerability_impact -> count for vulnerabilities (flattened array)
+          type: object
+          additionalProperties:
+            type: integer
+        vuln_statuses:
+          description: Map of vuln_status -> count for vulnerabilities
+          type: object
+          additionalProperties:
+            type: integer
+        vuln_types:
+          description: Map of vulnerability_type -> count for vulnerabilities
+          type: object
+          additionalProperties:
+            type: integer
+        vulns_with_poc:
+          description: Number of vulnerabilities with PoC for this product
+          type: integer
     Vulnerability:
-      title: Vulnerability
+      additionalProperties: false
       allOf:
       - $ref: '#/components/schemas/VulnerabilityInfo'
       - $ref: '#/components/schemas/NucleiTemplate'
-      - type: object
-        properties:
+      - properties:
           affected_products:
-            type: array
+            description: Affected products for the vulnerability
             items:
               $ref: '#/components/schemas/ProductInfo'
+            type: array
           created_at:
-            type: string
+            description: Created at timestamp
             format: date-time
+            type: string
           doc_id:
+            description: Document ID of the vulnerability
             type: string
           doc_type:
+            description: Type of the document
             type: string
           exposure:
             $ref: '#/components/schemas/VulnExposure'
+            description: Exposure stats for the vulnerability
           h1:
             $ref: '#/components/schemas/H1Stats'
-          updated_at:
-            type: string
-            format: date-time
+            description: Hackerone stats for the vulnerability
           ntps:
+            description: Nuclei Template Priority Score
             type: integer
+          updated_at:
+            description: Updated at timestamp
+            format: date-time
+            type: string
+          template_created_at:
+            description: Timestamp when the template was created
+            format: date-time
+            type: string
+        type: object
+      type: object
     VulnerabilityInfo:
       additionalProperties: false
       allOf:
@@ -7837,6 +14376,23 @@ components:
             type: string
           vendor:
             description: Vendor associated with the vulnerability/template
+            type: string
+          requirement_type:
+            description: Type of the requirement
+            type: string
+          requirements:
+            description: Requirements for the vulnerability/template
+            type: string
+          template_coverage:
+            description: Coverage of the template
+            type: string
+          vulnerability_impact:
+            description: Impact of the vulnerability/template
+            items:
+              type: string
+            type: array
+          vulnerability_type:
+            description: Type of the vulnerability/template
             type: string
           weaknesses:
             description: Weaknesses associated with the vulnerability
@@ -7919,6 +14475,19 @@ components:
           items:
             $ref: '#/components/schemas/POC'
           type: array
+        nuclei_template:
+          description: Raw nuclei template content
+          type: string
+        is_auth:
+          description: True if the CVE is an authenticated CVE
+          type: boolean
+        is_exploit_seen:
+          description: True if the CVE has been exploited in the wild
+          type: boolean
+        poc_first_seen:
+          description: First seen date for the poc
+          format: date-time
+          type: string
         vuln_status:
           description: Status of the cve
           type: string
@@ -7949,6 +14518,7 @@ components:
         url:
           type: string
     Citation:
+      additionalProperties: false
       title: Citation
       type: object
       properties:
@@ -7962,8 +14532,13 @@ components:
             type: string
         url:
           type: string
-          description: Url for the citation
+          description: URL for the citation
+        added_at:
+          description: Added at date for the citation
+          format: date-time
+          type: string
     Weakness:
+      additionalProperties: false
       title: Weakness
       type: object
       properties:
@@ -7974,21 +14549,28 @@ components:
           type: string
           description: CWE Name for the weakness
     NucleiTemplate:
-      title: NucleiTemplate
+      additionalProperties: false
       allOf:
       - $ref: '#/components/schemas/TemplateSourceMeta'
       - $ref: '#/components/schemas/TemplateStatus'
       - $ref: '#/components/schemas/TemplateFileMeta'
       - $ref: '#/components/schemas/TemplateContent'
       - $ref: '#/components/schemas/TemplateSharingMetadata'
-      - type: object
-        properties:
+      - properties:
           ai_meta:
             $ref: '#/components/schemas/AIMeta'
+            description: AI Meta of the template
           classification:
             $ref: '#/components/schemas/Classification'
+            description: Classification of the template
           id:
+            description: ID of the template
             type: string
+          user_id:
+            description: User ID of the template
+            type: integer
+        type: object
+      type: object
     TemplateSharingMetadata:
       properties:
         organizations:
@@ -8055,14 +14637,8 @@ components:
         is_new:
           description: Is the template new
           type: boolean
-        is_pdresearch:
-          description: Is the template from pdresearch
-          type: boolean
         is_pdteam:
           description: Is the template from pdteam
-          type: boolean
-        is_pdtemplate:
-          description: Is the template from pdtemplate
           type: boolean
       type: object
     TemplateFileMeta:
@@ -8111,29 +14687,42 @@ components:
       type: object
       properties:
         cpe:
+          description: CPE of the product
           type: array
           items:
             type: string
         product:
+          description: Product of the product
           type: string
         project_repos:
           type: object
         projects:
+          description: Projects of the product
           type: array
           items:
             type: string
         vendor:
+          description: Vendor of the product
           type: string
         product_category:
           type: string
         product_type:
           type: string
         industry:
+          description: Industry of the product
           type: string
         tech_domain:
+          description: Tech domain of the product
           type: string
-        is_pd:
-          type: boolean
+        category:
+          description: Product category of the product
+          type: string
+        deployment_model:
+          description: Deployment model of the product
+          type: string
+        summary:
+          description: Summary of the product
+          type: string
     SearchEngineStats:
       title: SearchEngineStats
       type: object
@@ -8164,28 +14753,37 @@ components:
         shodan:
           $ref: '#/components/schemas/SearchEngineStats'
     VulnExposure:
+      additionalProperties: false
       title: VulnExposure
       type: object
       properties:
         max_hosts:
+          description: Maximum number of hosts for the vulnerability
           type: integer
         min_hosts:
+          description: Minimum number of hosts for the vulnerability
           type: integer
         values:
+          description: Values of the vulnerability
           type: array
           items:
             $ref: '#/components/schemas/ExposureStats'
     H1Stats:
+      additionalProperties: false
       title: H1Stats
       type: object
       properties:
         delta_rank:
+          description: Rank delta from previous day
           type: integer
         delta_reports:
+          description: Reports delta from previous day
           type: integer
         rank:
+          description: Rank of CVE in Hackerone
           type: integer
         reports:
+          description: Number of reports for CVE
           type: integer
     StatisticsResponse:
       title: StatisticsResponse
@@ -8207,8 +14805,69 @@ components:
       title: LeaksEntityStatus
       enum:
       - fixed
-      - unfixed
+      - open
       - NA
+    StripePriceItem:
+      title: StripePriceItem
+      type: object
+      required:
+      - price_id
+      - price
+      - name
+      properties:
+        price_id:
+          type: string
+          description: Stripe price ID
+        price:
+          type: number
+          description: Price amount in dollars
+        name:
+          type: string
+          description: Price display name
+        currency:
+          type: string
+          description: Currency code (e.g., USD)
+        interval:
+          type: string
+          description: Billing interval (month, year, etc.)
+        product_id:
+          type: string
+          description: Associated Stripe product ID
+    PlanDefaultLimit:
+      title: PlanDefaultLimit
+      type: object
+      required:
+      - plan
+      - asset_limit
+      - domain_limit
+      properties:
+        plan:
+          type: string
+          enum:
+          - ENT
+          - ENT_TRIAL
+          - PRO
+          - GROWTH
+          - TRIAL
+          - FREE
+          - VERIFIED_FREE
+          description: Plan type
+        asset_limit:
+          type: integer
+          format: int64
+          description: Default asset limit for the plan
+        domain_limit:
+          type: integer
+          format: int64
+          description: Default domain limit for the plan
+        created_at:
+          type: string
+          format: date-time
+          description: Creation timestamp
+        updated_at:
+          type: string
+          format: date-time
+          description: Last update timestamp
   securitySchemes:
     X-API-Key:
       name: X-API-Key
@@ -8377,6 +15036,8 @@ components:
                 type: boolean
               static_scan:
                 type: boolean
+              neo_ai:
+                type: boolean
               early_template:
                 type: boolean
               team_name:
@@ -8399,10 +15060,29 @@ components:
                 type: string
               full_port_scan:
                 type: boolean
+              is_leaks_enabled:
+                type: boolean
               workspaces:
                 type: array
                 items:
                   $ref: '#/components/schemas/UserWorkspaces'
+              real_time_auto_scan:
+                type: boolean
+              growth_plan_availability:
+                type: object
+                properties:
+                  price_id:
+                    type: string
+                    description: Stripe price ID for growth plan
+                  is_available:
+                    type: boolean
+                    description: Whether growth plan is available for this user to buy
+                  amount:
+                    type: number
+                    description: Price amount in dollars
+                  recurrence_period:
+                    type: string
+                    description: Billing period (MONTHLY/YEARLY)
     DeleteTemplateResponse:
       description: Example response
       content:
@@ -9000,6 +15680,8 @@ components:
                 type: boolean
               static_scan:
                 type: boolean
+              neo_ai:
+                type: boolean
               early_template:
                 type: boolean
             required:
@@ -9018,6 +15700,8 @@ components:
               scan_status:
                 type: boolean
               static_scan:
+                type: boolean
+              neo_ai:
                 type: boolean
               early_template:
                 type: boolean
@@ -9463,6 +16147,8 @@ components:
               old_plan_expired_at:
                 type: string
                 format: date-time
+              is_enforced_limit:
+                type: boolean
               subscription_type:
                 enum:
                 - TRIAL
@@ -9481,11 +16167,15 @@ components:
             required:
             - message
             - asset_count
+            - async
             properties:
               message:
                 type: string
               asset_count:
                 type: integer
+              async:
+                type: boolean
+                description: Whether the operation is running asynchronously
     GetAssetChangelogsResponse:
       description: Example response
       content:
@@ -10141,6 +16831,10 @@ components:
                 type: boolean
               scan_all_assets:
                 type: boolean
+              exclusions:
+                type: array
+                items:
+                  type: string
     SetScanScheduleRequest:
       content:
         application/json:
@@ -10243,6 +16937,8 @@ components:
                 type: boolean
               static_scan:
                 type: boolean
+              neo_ai:
+                type: boolean
               early_template:
                 type: boolean
               max_team:
@@ -10254,6 +16950,8 @@ components:
               cloud_region:
                 type: string
               full_port_scan:
+                type: boolean
+              is_leaks_enabled:
                 type: boolean
             required:
             - email
@@ -10458,6 +17156,16 @@ components:
                 type: array
                 items:
                   type: string
+              scan_ids:
+                type: array
+                items:
+                  type: string
+                description: Optional scan IDs to scope these rules to specific scans. If not provided, rules apply globally.
+              enumeration_ids:
+                type: array
+                items:
+                  type: string
+                description: Optional enumeration IDs to scope these rules to specific enumerations. If not provided, rules apply globally.
               exclude_type:
                 $ref: '#/components/schemas/ExcludeConfigRequestType'
     DeleteExcludedConfigRequest:


### PR DESCRIPTION
- Add new consolidated leaks API endpoints documentation
- Add export, info, status, and stats endpoints
- Update navigation to show current endpoints only
- Mark deprecated endpoints with migration guides
- Filter out internal/admin endpoints from OpenAPI spec
- Fix generic endpoint summaries
- Remove premium subscription requirements
- Clean up icons and use cases sections

New endpoints documented:
- GET /v1/leaks (consolidated endpoint)
- POST /v1/leaks/export (export functionality)
- POST /v1/leaks/info (detailed leak info)
- POST /v1/leaks/status (status management)
- GET /v1/leaks/stats/domain (domain statistics)
- GET /v1/leaks/stats/email (email statistics)

Changes:
- Updated mint.json navigation
- Filtered openapi.yaml (49 internal endpoints removed)
- Added 6 new documentation files
- Updated 3 deprecated endpoint files
- Fixed verification requirements (domain verification only)