### PR TITLE
fix broken Getting Started links

### DIFF
--- a/cloud/free/overview.mdx
+++ b/cloud/free/overview.mdx
@@ -25,7 +25,7 @@ To get started with PDCP Free you'll need two things:
 - Scan results from Nuclei
 - a PDCP Login/Setup
 
-If you already have Nuclei scan results, or you've walked through our [Getting Started example](/getstarted-overview) using Nuclei, you're most of the way there. 
+If you already have Nuclei scan results, or you've walked through our [Getting Started example](/quickstart) using Nuclei, you're most of the way there. 
 
 ## What's in this User Guide?
 

--- a/opensource/nuclei/overview.mdx
+++ b/opensource/nuclei/overview.mdx
@@ -12,7 +12,7 @@ At its core, Nuclei uses templates—expressed as straightforward YAML files, th
 
 Each template delineates a possible attack route, detailing the vulnerability, its severity, priority rating, and occasionally associated exploits. This template-centric methodology ensures Nuclei not only identifies potential threats, but pinpoints exploitable vulnerabilities with tangible real-world implications.
 
-New to scanners and Nuclei? Try it out today with a quick example through our [Getting Started](/getstarted-overview).
+New to scanners and Nuclei? Try it out today with a quick example through our [Getting Started](/quickstart).
 
 ## What are Nuclei's features?
 


### PR DESCRIPTION
Fix `/getstarted-overview` 404 links to `/quickstart` in `opensource/nuclei/overview.mdx` and `cloud/free/overview.mdx`.

Closes #219